### PR TITLE
BPS-17/Chip 컴포넌트 제작

### DIFF
--- a/src/components/common/Chip/Chip.module.scss
+++ b/src/components/common/Chip/Chip.module.scss
@@ -2,8 +2,10 @@
   @include typo(12);
 
   display: inline-block;
+  min-width: 54px;
   padding: 3px 8px;
   border-radius: 100px;
+  text-align: center;
 }
 
 .increase {

--- a/src/components/common/Chip/Chip.module.scss
+++ b/src/components/common/Chip/Chip.module.scss
@@ -1,0 +1,22 @@
+.chipBox {
+  @include typo(12);
+
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 100px;
+}
+
+.increase {
+  background-color: $point-color-green1;
+  color: $point-color-green2;
+}
+
+.decrease {
+  background-color: $point-color-red1;
+  color: $point-color-red2;
+}
+
+.same {
+  background-color: $sub-color2;
+  color: $sub-color3;
+}

--- a/src/components/common/Chip/Chip.tsx
+++ b/src/components/common/Chip/Chip.tsx
@@ -6,6 +6,10 @@ type Fluctuation = "increase" | "decrease" | "same";
 
 const cx = classNames.bind(styles);
 
+/**
+ * @param percentage 백분율 값
+ * @returns 백분율을 나타내는 Chip 컴포넌트
+ */
 const Chip = ({ percentage }: { percentage: number }) => {
   let fluctuation: Fluctuation;
 

--- a/src/components/common/Chip/Chip.tsx
+++ b/src/components/common/Chip/Chip.tsx
@@ -1,0 +1,25 @@
+import classNames from "classnames/bind";
+
+import styles from "./Chip.module.scss";
+
+type Fluctuation = "increase" | "decrease" | "same";
+
+const cx = classNames.bind(styles);
+
+const Chip = ({ percentage }: { percentage: number }) => {
+  let fluctuation: Fluctuation;
+
+  if (percentage > 0) {
+    fluctuation = "increase";
+  } else if (percentage === 0) {
+    fluctuation = "same";
+  } else {
+    fluctuation = "decrease";
+  }
+
+  return (
+    <div className={cx("chipBox", fluctuation)}>{`${percentage}%`}</div>
+  );
+};
+
+export default Chip;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -17,9 +17,9 @@ $point-color-blue4: #387ffd !default;
 
 /* point-color-red */
 $point-color-red1: #ffd8d8 !default;
-$point-color-red2: #ff000f !default;
+$point-color-red2: #f00 !default;
 
-/* point-color-red */
+/* point-color-green */
 $point-color-green1: #caf4d3 !default;
 $point-color-green2: #00c02a !default;
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
- 백분율 값을 받아 증감에 따라 색을 달리하는 Chip 컴포넌트 제작
![화면 캡처 2023-08-07 155911](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/d4a03046-0d5a-432a-b495-cd021a92b0e3)

### How it Works
- prop으로 백분율 number 값을 넘겨줍니다.
```
<Chip percentage={당월 금액 - 전월 금액} />
```

### To Reviewers
- 디자인 시안에서는 소수점 아래가 있고 없고에 따라 width가 차이가 나는데, 제 생각엔 width를 통일시키는 게 좋을 것 같아요. 다들 어떻게 생각하시는지 궁금합니다😮 **(반영 완료)**
1. 기존 디자인 
![화면 캡처 2023-08-07 155911](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/b40d768d-3438-4dbc-b444-5955857a8b24)


2. width를 통일시킬 시
![화면 캡처 2023-08-07 155837](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/07defaa8-fcf7-4b7f-b3f3-cd72f61b6d8b)

- 글로벌 color의 red2 hex 코드가 디자인 시안과 다른 점이 있어 이 부분 수정했습니다!