### PR TITLE
BPS-36/일반 버튼 컴포넌트 & 금액 포맷 함수 제작

### DIFF
--- a/src/components/common/CommonBtns/Button/Button.module.scss
+++ b/src/components/common/CommonBtns/Button/Button.module.scss
@@ -1,0 +1,41 @@
+.button {
+  // 사이즈 별
+  &.large {
+    width: 348px;
+  }
+
+  &.medium {
+    width: 218px;
+  }
+
+  &.small {
+    width: 125px;
+  }
+
+  // 테마 별
+  &.bright {
+    border: 1px solid $sub-color2;
+    background-color: $sub-color1;
+    color: $primary-black;
+
+    &.isTextEmphasis {
+      color: $point-color-blue4;
+    }
+  }
+
+  &.dark {
+    background-color: $primary-black;
+    color: $primary-white;
+  }
+
+  // 공통
+  @include typo(16);
+
+  padding-top: 18px;
+  padding-bottom: 18px;
+  border-radius: 6px;
+
+  &:disabled {
+    cursor: default;
+  }
+}

--- a/src/components/common/CommonBtns/Button/Button.tsx
+++ b/src/components/common/CommonBtns/Button/Button.tsx
@@ -25,7 +25,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
  *
  * @example
  * <Button size="large" theme="bright" isTextEmphasis onClick={onClick}>수록곡 추가</Button>
- * <Button size="large" theme="dark" disabled onSubmit={onSubmit}>가입하기</Button>
+ * <Button size="large" theme="dark" disabled onSubmit={onSubmit} type="submit">가입하기</Button>
  *
  */
 const Button = ({

--- a/src/components/common/CommonBtns/Button/Button.tsx
+++ b/src/components/common/CommonBtns/Button/Button.tsx
@@ -14,7 +14,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 /**
- * @author 연우킴
+ * @author 연우킴 https://github.com/drizzle96
  * @param {string} size - 버튼의 크기를 지정합니다. "small", "medium", "large" 중 하나의 값이어야 합니다.
  * @param {string} theme - 버튼의 테마를 지정합니다. "dark", "bright" 중 하나의 값이어야 합니다.
  * @param {Function} onClick - 버튼 클릭 시 실행되는 콜백 함수입니다.

--- a/src/components/common/CommonBtns/Button/Button.tsx
+++ b/src/components/common/CommonBtns/Button/Button.tsx
@@ -1,0 +1,24 @@
+import classNames from "classnames/bind";
+
+import styles from "./Button.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size: "large" | "medium" | "small";
+  theme: "bright" | "dark";
+  onClick?: () => void;
+  onSubmit?: () => void;
+  isTextEmphasis?: boolean;
+  children: React.ReactNode;
+}
+
+const Button = ({
+  size, theme, onClick, onSubmit, isTextEmphasis = false, children, ...props
+}: ButtonProps) => {
+  return (
+    <button className={cx("button", { [size]: size, [theme]: theme, isTextEmphasis })} onClick={onClick} onSubmit={onSubmit} {...props}>{children}</button>
+  );
+};
+
+export default Button;

--- a/src/components/common/CommonBtns/Button/Button.tsx
+++ b/src/components/common/CommonBtns/Button/Button.tsx
@@ -17,7 +17,7 @@ const Button = ({
   size, theme, onClick, onSubmit, isTextEmphasis = false, children, ...props
 }: ButtonProps) => {
   return (
-    <button className={cx("button", { [size]: size, [theme]: theme, isTextEmphasis })} onClick={onClick} onSubmit={onSubmit} {...props}>{children}</button>
+    <button className={cx("button", { [size]: size, [theme]: theme, isTextEmphasis })} onClick={onClick} onSubmit={onSubmit} type="button" {...props}>{children}</button>
   );
 };
 

--- a/src/components/common/CommonBtns/Button/Button.tsx
+++ b/src/components/common/CommonBtns/Button/Button.tsx
@@ -13,6 +13,21 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
 }
 
+/**
+ * @author 연우킴
+ * @param {string} size - 버튼의 크기를 지정합니다. "small", "medium", "large" 중 하나의 값이어야 합니다.
+ * @param {string} theme - 버튼의 테마를 지정합니다. "dark", "bright" 중 하나의 값이어야 합니다.
+ * @param {Function} onClick - 버튼 클릭 시 실행되는 콜백 함수입니다.
+ * @param {Function} onSubmit - 버튼이 폼 내부에 위치할 경우, 폼 제출 시 실행되는 콜백 함수입니다.
+ * @param {boolean} isTextEmphasis - 버튼 텍스트 강조 여부를 나타냅니다. 기본값은 false로 true로 설정하면 글자가 보라색 계열이 됩니다.
+ * (사용 위치: 앨범 수정-수록곡 추가 버튼)
+ * @param {...any} props - 기타 버튼 요소로써 추가적으로 전달되는 속성들입니다. (예시: type, disabled)
+ *
+ * @example
+ * <Button size="large" theme="bright" isTextEmphasis onClick={onClick}>수록곡 추가</Button>
+ * <Button size="large" theme="dark" disabled onSubmit={onSubmit}>가입하기</Button>
+ *
+ */
 const Button = ({
   size, theme, onClick, onSubmit, isTextEmphasis = false, children, ...props
 }: ButtonProps) => {

--- a/src/pages/ian.page.tsx
+++ b/src/pages/ian.page.tsx
@@ -1,0 +1,9 @@
+import Button from "@/components/common/CommonBtns/Button/Button";
+
+const Ian = () => {
+  return (
+    <div><Button size="large" theme="bright" type="button">text</Button></div>
+  );
+};
+
+export default Ian;

--- a/src/utils/utilFormatMoney.ts
+++ b/src/utils/utilFormatMoney.ts
@@ -1,0 +1,56 @@
+const formatMoneyForDoughnut = (money: number) => {
+  let formattedMoney = money;
+  const suffixes = ["", "K", "M", "B"];
+  let suffixIndex = 0;
+
+  while (formattedMoney >= 1000 && suffixIndex < suffixes.length - 1) {
+    formattedMoney /= 1000;
+    suffixIndex += 1;
+  }
+
+  let formattedNum;
+  if (suffixIndex === 0 || formattedMoney >= 100) {
+    formattedNum = formattedMoney.toFixed(0);
+  } else if (formattedMoney >= 10) {
+    formattedNum = formattedMoney.toFixed(1);
+  } else {
+    formattedNum = formattedMoney.toFixed(2);
+  }
+
+  return `₩${formattedNum}${suffixes[suffixIndex]}`;
+};
+
+const formatLargeNum = (num: number, unit: number) => {
+  const numDigits = (num / unit).toString().split(".")[1]?.length || 0;
+  const formattedNum = (numDigits <= 3)
+    ? (Math.round((num / unit) * 1000) / 1000).toFixed(numDigits)
+    : (Math.round((num / unit) * 1000) / 1000).toFixed(3);
+  return formattedNum;
+};
+
+/**
+ * @author 연우킴 https://github.com/drizzle96
+ * @param money 금액
+ * @param formatType 금액 포맷 타입을 지정합니다. "card", "doughnut", "table" 중 하나의 값이어야 합니다.
+ * @returns 타입에 맞게 포맷된 string 형태의 금액
+ */
+const utilFormatMoney = (money: number, formatType: "card" | "doughnut" | "table") => {
+  if (!money && money !== 0) return "-";
+  const unit = 100000000;
+  switch (formatType) {
+    case "card":
+      if (money >= unit) {
+        return `${formatLargeNum(money, unit)}억원`;
+      } return `${money.toLocaleString("ko-KR")}원`;
+    case "doughnut":
+      return formatMoneyForDoughnut(money);
+    case "table":
+      if (money >= unit) {
+        return `₩${formatLargeNum(money, unit)}억`;
+      } return `₩${money.toLocaleString("ko-KR")}`;
+    default:
+      return "-";
+  }
+};
+
+export default utilFormatMoney;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

- 공통 버튼 컴포넌트 중 일반 버튼 컴포넌트 제작
- 금액 포맷 util 함수 제작

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/daad0fde-e92c-464a-b778-5802494fb08c)

### How it Works

- 버튼 컴포넌트
    - common/CommonBtns/Button으로 작업했고, 이후 ChipButton이나 TextButton도 CommonBtns 안에 폴더로 만들어서 작업할 예정입니다.
    - Button은 size, theme 등의 커스텀 prop 외에 일반적으로 버튼 태그가 갖는 disabled, type prop을 받을 수 있게 설계 돼있습니다.
    - 구체적인 예시는 javadoc 참고
- 금액 포맷 util 함수
    - 금액과 card, doughnut, table 3종류의 타입을 받아 string으로 포맷해주는 함수입니다.
    - 기획서의 아래 내용을 근거로 제작하였습니다.
 
> 1. 금액 카드
억 미만 금액은 ‘원’으로 표시하고, 억 이상 금액은 ‘억 원’으로 표시
> 2. 도넛 차트 매출 금액
금액 앞에 ₩ 단위 붙임
금액 뒤에
천 ~ 십만: ‘K’ 단위
백만 ~ 1억: ‘M’ 단위
10억 ~ : ‘B’ 단위
> 3. 트랙별 리스트
금액 앞에 ₩ 단위 붙임
억 이상 금액에만 금액 뒤에 ‘억’ 단위 붙임

### To Reviewers

- 버튼의 인터페이스가 적절한지 확인 부탁드립니다~!
