### PR TITLE
BPS-58/Popover 컴포넌트 추가

### DIFF
--- a/src/components/common/Popover/Popover.tsx
+++ b/src/components/common/Popover/Popover.tsx
@@ -14,6 +14,35 @@ interface PopoverProps {
   children: React.ReactNode;
 }
 
+/**
+ * 팝오버 컴포넌트
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param {InsetValue} top
+ *  팝오버 컴포넌트의 위치 관련 top inset 값 (position relative부모 기준))
+ * @param {InsetValue} left
+ *  팝오버 컴포넌트의 위치 관련 top inset 값 (position relative부모 기준))
+ * @param {InsetValue} right
+ *  팝오버 컴포넌트의 위치 관련 top inset 값 (position relative부모 기준))
+ * @param {InsetValue} bottom
+ *  팝오버 컴포넌트의 위치 관련 top inset 값 (position relative부모 기준))
+ * @param {Function} onClose 팝오버 바깥 영역 클릭 시 실행할 콜백함수 (주로 팝오버를 닫는 함수가 될 것 같습니다)
+ *
+ * @param {ReactNode} children 팝오버 안의 내용이 될 자식 컴포넌트들
+ *
+ * @example
+ * ```
+ * <div className="popover-parent" style={{position: "relative"}}>
+ *  { isPopoverOpen &&
+ *   <Popover
+ *     top="10px" // popoverParent기준으로 해당 팝오버는 10px 아래에서 나타남
+ *     onClose={()=>{setIsPopoverOpen(false)}}
+ *   >
+ *     <div>팝오버 내용</div>
+ *   </Popover>
+ *  }
+ * </div>
+ *```
+ */
 const Popover = React.memo(({
   top,
   left,

--- a/src/components/common/Popover/Popover.tsx
+++ b/src/components/common/Popover/Popover.tsx
@@ -1,0 +1,44 @@
+import React, { useRef } from "react";
+
+import useOutsideClick from "@/hooks/useOutsideClick";
+
+type Unit = "px" | "rem" | "em" | "%" | "vh" | "vw" | "vmin" | "vmax";
+type InsetValue = `${number}${Unit}`;
+
+interface PopoverProps {
+  top?: InsetValue;
+  left?: InsetValue;
+  right?: InsetValue;
+  bottom?: InsetValue;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Popover = React.memo(({
+  top,
+  left,
+  right,
+  bottom,
+  onClose,
+  children,
+}: PopoverProps) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(popoverRef, onClose);
+  return (
+    <div
+      style={{
+        position: "absolute",
+        display: "flex",
+        top: `${top ?? "auto"}`,
+        left: `${left ?? "auto"}`,
+        right: `${right ?? "auto"}`,
+        bottom: `${bottom ?? "auto"}`,
+      }}
+      ref={popoverRef}
+    >
+      {children}
+    </div>
+  );
+});
+
+export default Popover;

--- a/src/components/common/Popover/__tests__/Popover.test.tsx
+++ b/src/components/common/Popover/__tests__/Popover.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import Popover from "@/components/common/Popover/Popover";
+
+describe("팝오버 컴포넌트 렌더링 테스트", () => {
+  it("should render properly", () => {
+    const onClick = jest.fn();
+    render(
+      <Popover onClose={onClick}>
+        <div>팝오버 컨텐츠</div>
+      </Popover>,
+    );
+    expect(screen.getByText(/팝오버 컨텐츠/i)).toBeInTheDocument();
+  });
+  it("should close when clicked outside", () => {
+    const handleClose = jest.fn();
+    const handleClickOutside = jest.fn();
+    render(
+      <>
+        <Popover onClose={handleClose}>
+          <div>팝오버 컨텐츠</div>
+        </Popover>
+        <button onClick={handleClickOutside}>외부 영역</button>
+      </>,
+    );
+    fireEvent.click(screen.getByText(/외부 영역/i));
+    expect(handleClose).toBeCalledTimes(1);
+  });
+});

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -7,6 +7,7 @@ const useOutsideClick = (
   callback: CallbackFunction,
 ) => {
   const handleClick = (e: MouseEvent) => {
+    e.stopPropagation();
     if (ref.current && !ref.current.contains(e.target as Node)) {
       callback();
     }
@@ -15,7 +16,7 @@ const useOutsideClick = (
   useEffect(() => {
     document.addEventListener("click", handleClick, { capture: true });
     return () => {
-      document.removeEventListener("click", handleClick);
+      document.removeEventListener("click", handleClick, { capture: true });
     };
   });
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 팝오버 컴포넌트 제작했습니다.

### How it Works
<!-- 간단한 로직 설명 -->
- 이번에 추가된 팝오버 컴포넌트는 보조 컴포넌트입니다. children을 팝오버로 만들어주는 보조역할을 합니다. 아래는 사용법 및 예시입니다.
```jsx
    <div style={{ position: "relative" }}>  {/* 이 div가 Popover의 positioning에 기준이 되는 div입니다. 사용할 때 position: relative 주셔야 합니다. */}
        <button type="button" onClick={() => { setIsPopoverOpen((prev) => { return !prev; }); }}>Open Popover</button>
        {isPopoverOpen && ( // isPopoverOpen과 같은 boolean변수를 상태로 정의하고 씁니다. 
          <Popover onClose={() => { setIsPopoverOpen(false); }} bottom="8rem">
            <Dropdown
              optionList={OPTION_LIST}
              onClose={() => { setIsPopoverOpen(false); }}
            />
          </Popover>
        )}
    </div>
```
- 참고로 팝오버에 useOutsideClick이 적용되어 있습니다. 그래서 onClose를 prop으로 받습니다. onClose는 팝오버 바깥 영역을 클릭했을 때 실행할 콜백함수입니다. 
### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
