### PR TITLE
BPS-70-Tooltip ellipsis 확인 로직 추가

### DIFF
--- a/src/components/common/Tooltip/Tooltip.utils.ts
+++ b/src/components/common/Tooltip/Tooltip.utils.ts
@@ -14,7 +14,7 @@ const getPosition = (ref: React.RefObject<HTMLElement>, gap = 10): PosType => {
   };
 };
 
-const checkTextOverflow = (elem: Element) => {
+const checkTextOverflow = (elem: Element): boolean => {
   if (elem.clientWidth < elem.scrollWidth) {
     return true;
   }

--- a/src/components/common/Tooltip/Tooltip.utils.ts
+++ b/src/components/common/Tooltip/Tooltip.utils.ts
@@ -14,5 +14,12 @@ const getPosition = (ref: React.RefObject<HTMLElement>, gap = 10): PosType => {
   };
 };
 
+const checkTextOverflow = (elem: Element) => {
+  if (elem.clientWidth < elem.scrollWidth) {
+    return true;
+  }
+  return false;
+};
+
 export type { PosType };
-export { getPosition };
+export { getPosition, checkTextOverflow };

--- a/src/components/common/Tooltip/Tooltip.utils.ts
+++ b/src/components/common/Tooltip/Tooltip.utils.ts
@@ -2,7 +2,7 @@ interface PosType {
   style: { x: number, y: number };
 }
 
-const getPosition = (ref: React.RefObject<HTMLElement>, gap = 10): PosType => {
+const utilGetPosition = (ref: React.RefObject<HTMLElement>, gap = 10): PosType => {
   const rect = ref.current?.getBoundingClientRect() || {
     top: 0, left: 0, width: 0, height: 0,
   };
@@ -14,7 +14,7 @@ const getPosition = (ref: React.RefObject<HTMLElement>, gap = 10): PosType => {
   };
 };
 
-const checkTextOverflow = (elem: Element): boolean => {
+const utilCheckTextOverflow = (elem: Element): boolean => {
   if (elem.clientWidth < elem.scrollWidth) {
     return true;
   }
@@ -22,4 +22,4 @@ const checkTextOverflow = (elem: Element): boolean => {
 };
 
 export type { PosType };
-export { getPosition, checkTextOverflow };
+export { utilGetPosition, utilCheckTextOverflow };

--- a/src/components/common/Tooltip/TooltipRoot.tsx
+++ b/src/components/common/Tooltip/TooltipRoot.tsx
@@ -1,7 +1,9 @@
-import { useState, useRef } from "react";
+import {
+  useState, useRef, MouseEvent,
+} from "react";
 
 import Tooltip from "./Tooltip";
-import { getPosition, PosType } from "./Tooltip.utils";
+import { checkTextOverflow, getPosition, PosType } from "./Tooltip.utils";
 import TooltipPortal from "./TooltipPortal";
 
 interface TooltipRootProps {
@@ -29,9 +31,10 @@ const TooltipRoot = ({ children, message }: TooltipRootProps) => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const pos = useRef<PosType | null>(null);
 
-  const handleMouseOver = () => {
+  const handleMouseOver = (e: MouseEvent<HTMLDivElement>) => {
     pos.current = getPosition(ref);
-    setIsVisible(true);
+    const visible = checkTextOverflow(e.currentTarget.children[0]);
+    setIsVisible(visible);
   };
 
   return (

--- a/src/components/common/Tooltip/TooltipRoot.tsx
+++ b/src/components/common/Tooltip/TooltipRoot.tsx
@@ -33,7 +33,7 @@ const TooltipRoot = ({ children, message }: TooltipRootProps) => {
 
   const handleMouseOver = (e: MouseEvent<HTMLDivElement>) => {
     pos.current = getPosition(ref);
-    const visible = checkTextOverflow(e.currentTarget.children[0]);
+    const visible = checkTextOverflow(e.currentTarget?.children[0]);
     setIsVisible(visible);
   };
 

--- a/src/components/common/Tooltip/TooltipRoot.tsx
+++ b/src/components/common/Tooltip/TooltipRoot.tsx
@@ -3,7 +3,7 @@ import {
 } from "react";
 
 import Tooltip from "./Tooltip";
-import { checkTextOverflow, getPosition, PosType } from "./Tooltip.utils";
+import { utilCheckTextOverflow, utilGetPosition, PosType } from "./Tooltip.utils";
 import TooltipPortal from "./TooltipPortal";
 
 interface TooltipRootProps {
@@ -32,8 +32,8 @@ const TooltipRoot = ({ children, message }: TooltipRootProps) => {
   const pos = useRef<PosType | null>(null);
 
   const handleMouseOver = (e: MouseEvent<HTMLDivElement>) => {
-    pos.current = getPosition(ref);
-    const visible = checkTextOverflow(e.currentTarget?.children[0]);
+    pos.current = utilGetPosition(ref);
+    const visible = utilCheckTextOverflow(e.currentTarget?.children[0]);
     setIsVisible(visible);
   };
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
- ellipsis 되는 곳만 Tooltip 노출을 해야 하며, 또 사용하는 곳이 많다보니 외부에서 일일이 ellipsis 여부를 확인하기보단 Tooltip 컴포넌트 내부에서 처리하는 것이 좋을 것 같아 로직을 추가했습니다. (설명해준 @drizzle96 에게 감사를~)
- 사용법은 이전과 동일합니다!

### Key Changes
- children으로 받는 hover 대상 요소의 ellipsis 적용 여부를 확인하는 로직을 추가
