### PR TITLE
BPS-86/Layouts 컴포넌트 제작

### DIFF
--- a/src/components/common/Dropdown/DropdownUI.module.scss
+++ b/src/components/common/Dropdown/DropdownUI.module.scss
@@ -1,9 +1,6 @@
 .dropdownContainer {
   @include flexbox(column, center, center);
 
-  width: 100%;
-  height: 100%;
-
   .dropdownValueContainer {
     position: relative;
     width: 89px;

--- a/src/components/common/Layouts/MainLayout.module.scss
+++ b/src/components/common/Layouts/MainLayout.module.scss
@@ -1,0 +1,14 @@
+.container {
+  @include flexbox(column);
+
+  width: 1200px;
+  margin: 38px auto;
+  margin-bottom: 50px;
+  gap: 50px;
+
+  .title {
+    @include typo(24, bold);
+
+    color: $primary-black;
+  }
+}

--- a/src/components/common/Layouts/MainLayout.module.scss
+++ b/src/components/common/Layouts/MainLayout.module.scss
@@ -2,8 +2,7 @@
   @include flexbox(column);
 
   width: 1200px;
-  margin: 38px auto;
-  margin-bottom: 50px;
+  margin: 38px auto 50px;
   gap: 50px;
 
   .title {

--- a/src/components/common/Layouts/MainLayout.tsx
+++ b/src/components/common/Layouts/MainLayout.tsx
@@ -9,6 +9,15 @@ interface MainLayoutProps {
   children: React.ReactNode
 }
 
+/**
+ * #### 페이지 전체를 감싸는 제목과 내용으로만 이루어진 레이아웃
+ * ##### 사용처: 아티스트 등록, 앨범 등록, 앨범 탐색, 아티스트 계정 관리, 내 프로필
+ *
+ * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
+ * @param {string} title - 레이아웃의 제목입니다.
+ * @param {React.ReactNode} children - 레이아웃의 내용 컴포넌트입니다.
+ *
+ */
 const MainLayout = ({ title, children }: MainLayoutProps) => {
   return (
     <section className={cx("container")}>

--- a/src/components/common/Layouts/MainLayout.tsx
+++ b/src/components/common/Layouts/MainLayout.tsx
@@ -1,0 +1,21 @@
+import classNames from "classnames/bind";
+
+import styles from "./MainLayout.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface MainLayoutProps {
+  title: string
+  children: React.ReactNode
+}
+
+const MainLayout = ({ title, children }: MainLayoutProps) => {
+  return (
+    <section className={cx("container")}>
+      <h1 className={cx("title")}>{title}</h1>
+      {children}
+    </section>
+  );
+};
+
+export default MainLayout;

--- a/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
+++ b/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
@@ -2,8 +2,7 @@
   @include flexbox(column);
 
   width: 1200px;
-  margin: 32px auto;
-  margin-bottom: 50px;
+  margin: 32px auto 50px;
   gap: 32px;
 
   .titleContainer {

--- a/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
+++ b/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
@@ -1,0 +1,20 @@
+.container {
+  @include flexbox(column);
+
+  width: 1200px;
+  margin: 32px auto;
+  margin-bottom: 50px;
+  gap: 32px;
+
+  .titleContainer {
+    @include flexbox(row, flex-start, center);
+
+    gap: 32px;
+  }
+
+  .title {
+    @include typo(24, bold);
+
+    color: $primary-black;
+  }
+}

--- a/src/components/common/Layouts/MainLayoutWithDropdown.tsx
+++ b/src/components/common/Layouts/MainLayoutWithDropdown.tsx
@@ -1,0 +1,29 @@
+import classNames from "classnames/bind";
+
+import styles from "./MainLayoutWithDropdown.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface MainLayoutWithDropdownProps {
+  title: string
+  dropdownElement: React.ReactNode
+  children: React.ReactNode
+}
+
+const MainLayoutWithDropdown = ({
+  title,
+  dropdownElement,
+  children,
+}: MainLayoutWithDropdownProps) => {
+  return (
+    <section className={cx("container")}>
+      <div className={cx("titleContainer")}>
+        <h1 className={cx("title")}>{title}</h1>
+        {dropdownElement}
+      </div>
+      {children}
+    </section>
+  );
+};
+
+export default MainLayoutWithDropdown;

--- a/src/components/common/Layouts/MainLayoutWithDropdown.tsx
+++ b/src/components/common/Layouts/MainLayoutWithDropdown.tsx
@@ -10,6 +10,15 @@ interface MainLayoutWithDropdownProps {
   children: React.ReactNode
 }
 
+/**
+ * #### 페이지 전체를 감싸는 제목과 내용, 그리고 제목 옆 드롭다운 요소가 포함된 레이아웃
+ * ##### 사용처: 대시보드, 정산내역 업로드
+ *
+ * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
+ * @param {React.ReactNode} dropdownElement - 제목 옆 드롭다운이 포함된 컴포넌트입니다.
+ * @param {React.ReactNode} children - 레이아웃의 내용 컴포넌트입니다.
+ *
+ */
 const MainLayoutWithDropdown = ({
   title,
   dropdownElement,

--- a/src/components/common/Layouts/SectionLayout.module.scss
+++ b/src/components/common/Layouts/SectionLayout.module.scss
@@ -1,0 +1,13 @@
+.container {
+  @include flexbox(column);
+
+  // margin: 32px auto 50px; (디자이너님과 협의 후 결정)
+  width: 100%;
+  gap: 32px;
+
+  .title {
+    @include typo(16, bold);
+
+    color: $primary-black;
+  }
+}

--- a/src/components/common/Layouts/SectionLayout.tsx
+++ b/src/components/common/Layouts/SectionLayout.tsx
@@ -1,0 +1,29 @@
+import classNames from "classnames/bind";
+
+import styles from "./SectionLayout.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface SectionLayoutProps {
+  title: string
+  children: React.ReactNode
+}
+
+/**
+ * #### 섹션(페이지 절반 정도)을 감싸는 제목과 내용으로 이루어진 레이아웃
+ *
+ * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
+ * @param {string} title - 레이아웃의 제목입니다.
+ * @param {React.ReactNode} children - 레이아웃의 내용 컴포넌트입니다.
+ *
+ */
+const SectionLayout = ({ title, children }: SectionLayoutProps) => {
+  return (
+    <section className={cx("container")}>
+      <h2 className={cx("title")}>{title}</h2>
+      {children}
+    </section>
+  );
+};
+
+export default SectionLayout;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

MainLayout 컴포넌트 제작

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/b8edf15e-8521-48bf-a57c-d97820782020)

### Key Changes

<!-- 어떤 작업을 했는지 -->

MainLayout 컴포넌트 제작

### How it Works
<!-- 간단한 로직 설명 -->

- width를 1200px로 고정시키고 좌우 마진 auto 처리했습니다. (1200px 이하는 반응형으로 고려 안할테니)
- 사용 가능한 페이지가 정해져있으니 javadoc에 작성한 사용처에서 사용하시면 됩니다~!

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->

- 컴포넌트 이름 어떤가요..? 지금 만든건 `페이지 전체를 감싸는 레이아웃`이라 `MainLayout`을 붙여봤고, `페이지 부분 섹션을 감싸는 레이아웃`은 `SectionLayout`으로 이름 붙일까 했습니다.
- 드롭다운 container 크기가 넘쳐서 wookki 형과 얘기한 뒤 스타일 수정했습니다.