### PR TITLE
BPS-26/MonthPicker 컴포넌트 추가

### DIFF
--- a/public/images/btn-close-normal.svg
+++ b/public/images/btn-close-normal.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="btn_close_normal" d="M16 1L1 16M16 16L1 1" stroke="#A3AAB6"/>
+</svg>

--- a/src/components/common/AlbumCard/OptionsButton.tsx
+++ b/src/components/common/AlbumCard/OptionsButton.tsx
@@ -57,7 +57,7 @@ const OptionsButton = ({ albumId, albumTitle }: OptionsButtonProps) => {
             top="27px"
             right="-4px"
             onClose={() => {
-              setTimeout(() => { return setIsOpen(false); }, 10);
+              setIsOpen(false);
             }}
           >
             <ul className={cx("buttonList")}>

--- a/src/components/common/Dropdown/DropdownHandleUI.module.scss
+++ b/src/components/common/Dropdown/DropdownHandleUI.module.scss
@@ -1,7 +1,7 @@
 .chevron {
-	&.up {
-		transform: rotate(-180deg);
-	}
+  &.up {
+    transform: rotate(-180deg);
+  }
 
-	transition: transform 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
 }

--- a/src/components/common/Dropdown/DropdownHandleUI.module.scss
+++ b/src/components/common/Dropdown/DropdownHandleUI.module.scss
@@ -1,0 +1,7 @@
+.chevron {
+	&.up {
+		transform: rotate(-180deg);
+	}
+
+	transition: transform 0.3s ease-in-out;
+}

--- a/src/components/common/Dropdown/DropdownHandleUI.tsx
+++ b/src/components/common/Dropdown/DropdownHandleUI.tsx
@@ -1,0 +1,20 @@
+import classNames from "classnames/bind";
+
+import styles from "./DropdownHandleUI.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface DropdownHandleUIProps {
+  direction?: "up" | "down";
+  white?: boolean;
+}
+
+const DropdownHandleUI = ({ direction = "down", white }: DropdownHandleUIProps) => {
+  return (
+    <svg className={cx("chevron", { up: direction === "up" })} width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M1 1L6.26316 7L11.5 1" stroke={white ? "#F3F5F8" : "#a3aab6"} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+export default DropdownHandleUI;

--- a/src/components/common/MonthPicker/MonthPicker.module.scss
+++ b/src/components/common/MonthPicker/MonthPicker.module.scss
@@ -1,5 +1,5 @@
 .container {
-  @include flexbox(column, false, false);
+  @include flexbox(column);
 
   gap: 32px;
   position: relative;

--- a/src/components/common/MonthPicker/MonthPicker.module.scss
+++ b/src/components/common/MonthPicker/MonthPicker.module.scss
@@ -1,40 +1,40 @@
 .container {
-	@include flexbox(column, false, false);
+  @include flexbox(column, false, false);
 
-	gap: 32px;
-	position: relative;
-	width: 296px;
+  gap: 32px;
+  position: relative;
+  width: 296px;
 
-	// height: 644px;
-	padding: 32px;
-	border-radius: 6px;
-	background-color: $primary-white;
-	box-shadow: 0 1px 6px 0 rgb(0 0 0 / 11%);
-	color: $primary-black;
+  // height: 644px;
+  padding: 32px;
+  border-radius: 6px;
+  background-color: $primary-white;
+  box-shadow: 0 1px 6px 0 rgb(0 0 0 / 11%);
+  color: $primary-black;
 
-	.closeBtn {
-		position: absolute;
-		top: 32px;
-		right: 32px;
-		width: 15px;
-		height: 15px;
-		background-color: transparent;
-	}
+  .closeBtn {
+    position: absolute;
+    top: 32px;
+    right: 32px;
+    width: 15px;
+    height: 15px;
+    background-color: transparent;
+  }
 
-	.pickSection {
-		@include flexbox(column, center, flex-start);
+  .pickSection {
+    @include flexbox(column, center, flex-start);
 
-		& h2 {
-			@include typo(16, bold);
+    & h2 {
+      @include typo(16, bold);
 
-			margin-bottom: 32px;
-		}
-	}
+      margin-bottom: 32px;
+    }
+  }
 
-	.spacing {
-		width: 100%;
-		height: 1px;
-		margin-top: 18px;
-		background-color: $sub-color1;
-	}
+  .spacing {
+    width: 100%;
+    height: 1px;
+    margin-top: 18px;
+    background-color: $sub-color1;
+  }
 }

--- a/src/components/common/MonthPicker/MonthPicker.module.scss
+++ b/src/components/common/MonthPicker/MonthPicker.module.scss
@@ -5,7 +5,6 @@
   position: relative;
   width: 296px;
 
-  // height: 644px;
   padding: 32px;
   border-radius: 6px;
   background-color: $primary-white;

--- a/src/components/common/MonthPicker/MonthPicker.module.scss
+++ b/src/components/common/MonthPicker/MonthPicker.module.scss
@@ -1,0 +1,40 @@
+.container {
+	@include flexbox(column, false, false);
+
+	gap: 32px;
+	position: relative;
+	width: 296px;
+
+	// height: 644px;
+	padding: 32px;
+	border-radius: 6px;
+	background-color: $primary-white;
+	box-shadow: 0 1px 6px 0 rgb(0 0 0 / 11%);
+	color: $primary-black;
+
+	.closeBtn {
+		position: absolute;
+		top: 32px;
+		right: 32px;
+		width: 15px;
+		height: 15px;
+		background-color: transparent;
+	}
+
+	.pickSection {
+		@include flexbox(column, center, flex-start);
+
+		& h2 {
+			@include typo(16, bold);
+
+			margin-bottom: 32px;
+		}
+	}
+
+	.spacing {
+		width: 100%;
+		height: 1px;
+		margin-top: 18px;
+		background-color: $sub-color1;
+	}
+}

--- a/src/components/common/MonthPicker/MonthPicker.tsx
+++ b/src/components/common/MonthPicker/MonthPicker.tsx
@@ -22,7 +22,13 @@ interface MonthPickerProps {
   selectedMonth: MonthString;
   onClose: () => void;
 }
-
+/**
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param selectedYear {YearString} 현재 선택된 년도
+ * @param selectedMonth {MonthString} 현재 선택된 월 ("01" 포맷)
+ * @param onClose {Function} MonthPicker 팝오버 닫기 클릭 시 호출할 함수
+ * @returns
+ */
 const MonthPicker = ({ selectedYear, selectedMonth, onClose }: MonthPickerProps) => {
   const router = useRouter();
   const [currentSelectedYear, setCurrentSelectedYear] = useState(selectedYear);

--- a/src/components/common/MonthPicker/MonthPicker.tsx
+++ b/src/components/common/MonthPicker/MonthPicker.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import classNames from "classnames/bind";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+import { YEAR_OPTIONS, MONTH_OPTIONS } from "@/constants/monthPicker";
+import getParentPathFromUrl from "@/utils/getParentPathFromUrl";
+
+import Button from "../CommonBtns/Button/Button";
+
+import styles from "./MonthPicker.module.scss";
+import { MonthString, YearString } from "./MonthPicker.type";
+import { getMonthPath, isYearString } from "./MonthPicker.util";
+import PickerItemList from "./PickerItemList";
+
+const cx = classNames.bind(styles);
+
+interface MonthPickerProps {
+  selectedYear: YearString;
+  selectedMonth: MonthString;
+  onClose: () => void;
+}
+
+const MonthPicker = ({ selectedYear, selectedMonth, onClose }: MonthPickerProps) => {
+  const router = useRouter();
+  const [currentSelectedYear, setCurrentSelectedYear] = useState(selectedYear);
+  const [currentSelectedMonth, setCurrentSelectedMonth] = useState(selectedMonth);
+
+  const handleSelectOption = (option: YearString | MonthString) => {
+    if (isYearString(option)) {
+      setCurrentSelectedYear(option);
+    } else {
+      setCurrentSelectedMonth(option);
+    }
+  };
+
+  const getHref = () => {
+    const currentPath = router.asPath;
+    const basePath = getParentPathFromUrl(currentPath);
+    return `${basePath}/${getMonthPath(currentSelectedYear, currentSelectedMonth)}`;
+  };
+
+  return (
+    <div className={cx("container")}>
+      <button className={cx("closeBtn")} onClick={onClose}>
+        <Image src="/images/btn-close-normal.svg" fill alt="닫기 버튼" />
+      </button>
+      <div className={cx("pickSection")}>
+        <h2>년도 선택</h2>
+        <PickerItemList
+          optionList={YEAR_OPTIONS}
+          selectedOption={currentSelectedYear}
+          onSelect={handleSelectOption}
+        />
+        <div className={cx("spacing")} />
+      </div>
+      <div className={cx("pickSection")}>
+        <h2>월 선택</h2>
+        <PickerItemList
+          optionList={MONTH_OPTIONS}
+          selectedOption={currentSelectedMonth}
+          onSelect={handleSelectOption}
+        />
+        <div className={cx("spacing")} />
+      </div>
+      <Link href={getHref()}>
+        <Button style={{ width: "100%" }} size="large" theme="dark" onClick={onClose}>
+          선택 완료
+        </Button>
+      </Link>
+    </div>
+  );
+};
+
+export default MonthPicker;

--- a/src/components/common/MonthPicker/MonthPicker.type.ts
+++ b/src/components/common/MonthPicker/MonthPicker.type.ts
@@ -1,0 +1,2 @@
+export type MonthString = "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12";
+export type YearString = `${"20"}${number}${number}`;

--- a/src/components/common/MonthPicker/MonthPicker.util.ts
+++ b/src/components/common/MonthPicker/MonthPicker.util.ts
@@ -1,0 +1,24 @@
+import { MonthString, YearString } from "./MonthPicker.type";
+
+export const isYearString = (option: YearString | MonthString): option is YearString => {
+  return typeof option === "string" && option.startsWith("20") && option.length === 4;
+};
+
+export const getMonthPath = (year: YearString, month: MonthString) => {
+  return `${year}${month}`;
+};
+
+export const convertToYearMonthFormat = (input: string) => {
+  const year = input.slice(0, 4);
+  const month = input.slice(4);
+
+  const monthNames = [
+    "1월", "2월", "3월", "4월", "5월", "6월",
+    "7월", "8월", "9월", "10월", "11월", "12월",
+  ];
+
+  const monthIndex = parseInt(month, 10) - 1;
+  const monthName = monthNames[monthIndex];
+
+  return `${year}년 ${monthName}`;
+};

--- a/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
@@ -1,14 +1,14 @@
 .container {
-	position: relative;
-	width: 139px;
-	height: 40px;
-	padding: 12px 20px;
-	border-radius: 8px;
-	background-color: $primary-black;
-	color: $primary-white;
+  position: relative;
+  width: 139px;
+  height: 40px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  background-color: $primary-black;
+  color: $primary-white;
 
-	.textWrapper {
-		@include flexbox(row, space-between, center);
-		@include typo(14);
-	}
+  .textWrapper {
+    @include flexbox(row, space-between, center);
+    @include typo(14);
+  }
 }

--- a/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
@@ -1,0 +1,14 @@
+.container {
+	position: relative;
+	width: 139px;
+	height: 40px;
+	padding: 12px 20px;
+	border-radius: 8px;
+	background-color: $primary-black;
+	color: $primary-white;
+
+	.textWrapper {
+		@include flexbox(row, space-between, center);
+		@include typo(14);
+	}
+}

--- a/src/components/common/MonthPicker/MonthPickerDropdown.tsx
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.tsx
@@ -1,29 +1,44 @@
 import { useState } from "react";
 
 import classNames from "classnames/bind";
+import { useRouter } from "next/router";
 
 import DropdownHandleUI from "@/components/common/Dropdown/DropdownHandleUI";
 import Popover from "@/components/common/Popover/Popover";
+import getLastSegmentFromUrl from "@/utils/getLastSegmentFromUrl";
+import getMonthFromUrl from "@/utils/getMonthFromUrl";
+import getYearFromUrl from "@/utils/getYearFromUrl";
 
-// import MonthPicker from "./MonthPicker";
+import MonthPicker from "./MonthPicker";
+import { MonthString, YearString } from "./MonthPicker.type";
+import { convertToYearMonthFormat } from "./MonthPicker.util";
 import styles from "./MonthPickerDropdown.module.scss";
 
 const cx = classNames.bind(styles);
 
 const MonthPickerDropdown = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+  const currentYear = getYearFromUrl(router.asPath) as YearString;
+  const currentMonth = getMonthFromUrl(router.asPath) as MonthString;
+  const handleClose = () => {
+    setIsOpen(false);
+  };
   return (
     <button className={cx("container")} onClick={() => { setIsOpen((prev) => { return !prev; }); }}>
       <div className={cx("textWrapper")}>
-        <span>2023년 8월</span>
+        <span>{convertToYearMonthFormat(getLastSegmentFromUrl(router.asPath))}</span>
         <div className={cx("handleWrapper")}>
           <DropdownHandleUI white direction={isOpen ? "up" : "down"} />
         </div>
       </div>
       {isOpen && (
-        <Popover onClose={() => { setIsOpen(false); }}>
-          {/* <MonthPicker /> */}
-          <div>년/월 선택 UI</div>
+        <Popover onClose={handleClose}>
+          <MonthPicker
+            selectedYear={currentYear}
+            selectedMonth={currentMonth}
+            onClose={handleClose}
+          />
         </Popover>
       )}
     </button>

--- a/src/components/common/MonthPicker/MonthPickerDropdown.tsx
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.tsx
@@ -33,7 +33,7 @@ const MonthPickerDropdown = () => {
         </div>
       </div>
       {isOpen && (
-        <Popover onClose={handleClose}>
+        <Popover onClose={handleClose} top="50px" left="-76px">
           <MonthPicker
             selectedYear={currentYear}
             selectedMonth={currentMonth}

--- a/src/components/common/MonthPicker/MonthPickerDropdown.tsx
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+import classNames from "classnames/bind";
+
+import DropdownHandleUI from "@/components/common/Dropdown/DropdownHandleUI";
+import Popover from "@/components/common/Popover/Popover";
+
+// import MonthPicker from "./MonthPicker";
+import styles from "./MonthPickerDropdown.module.scss";
+
+const cx = classNames.bind(styles);
+
+const MonthPickerDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <button className={cx("container")} onClick={() => { setIsOpen((prev) => { return !prev; }); }}>
+      <div className={cx("textWrapper")}>
+        <span>2023년 8월</span>
+        <div className={cx("handleWrapper")}>
+          <DropdownHandleUI white direction={isOpen ? "up" : "down"} />
+        </div>
+      </div>
+      {isOpen && (
+        <Popover onClose={() => { setIsOpen(false); }}>
+          {/* <MonthPicker /> */}
+          <div>년/월 선택 UI</div>
+        </Popover>
+      )}
+    </button>
+  );
+};
+
+export default MonthPickerDropdown;

--- a/src/components/common/MonthPicker/PickerItem.module.scss
+++ b/src/components/common/MonthPicker/PickerItem.module.scss
@@ -1,15 +1,15 @@
 .container {
-	@include flexbox(row, center, flex-start);
-	@include typo(14);
+  @include flexbox(row, center, flex-start);
+  @include typo(14);
 
-	min-width: 65.34px;
-	padding: 10px 15px;
-	border: 1px solid $sub-color1;
-	border-radius: 100px;
-	background-color: transparent;
+  min-width: 65.34px;
+  padding: 10px 15px;
+  border: 1px solid $sub-color1;
+  border-radius: 100px;
+  background-color: transparent;
 
-	&.selected {
-		background-color: $point-color-blue1;
-		color: $point-color-blue3;
-	}
+  &.selected {
+    background-color: $point-color-blue1;
+    color: $point-color-blue3;
+  }
 }

--- a/src/components/common/MonthPicker/PickerItem.module.scss
+++ b/src/components/common/MonthPicker/PickerItem.module.scss
@@ -1,0 +1,15 @@
+.container {
+	@include flexbox(row, center, flex-start);
+	@include typo(14);
+
+	min-width: 65.34px;
+	padding: 10px 15px;
+	border: 1px solid $sub-color1;
+	border-radius: 100px;
+	background-color: transparent;
+
+	&.selected {
+		background-color: $point-color-blue1;
+		color: $point-color-blue3;
+	}
+}

--- a/src/components/common/MonthPicker/PickerItem.tsx
+++ b/src/components/common/MonthPicker/PickerItem.tsx
@@ -10,7 +10,12 @@ interface PickerItemProps {
   selected: boolean;
   onSelect: (arg1: YearString | MonthString) => void;
 }
-
+/**
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param textContent {YearStirng | MonthString} 연, 월 선택 버튼 내용(연, 월)
+ * @param selected {boolean} 아이템 선택 여부
+ * @param onSelect {Funtion} 아이템 선택 시 호출할 콜백함수
+ */
 const PickerItem = ({ textContent, selected = false, onSelect }: PickerItemProps) => {
   const handleSelectOption = () => {
     onSelect(textContent);

--- a/src/components/common/MonthPicker/PickerItem.tsx
+++ b/src/components/common/MonthPicker/PickerItem.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames/bind";
+
+import { MonthString, YearString } from "./MonthPicker.type";
+import styles from "./PickerItem.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface PickerItemProps {
+  textContent: YearString | MonthString;
+  selected: boolean;
+  onSelect: (arg1: YearString | MonthString) => void;
+}
+
+const PickerItem = ({ textContent, selected = false, onSelect }: PickerItemProps) => {
+  const handleSelectOption = () => {
+    onSelect(textContent);
+  };
+  return (
+    <button
+      className={cx("container", { selected })}
+      onClick={handleSelectOption}
+    >
+      {textContent}
+    </button>
+  );
+};
+
+export default PickerItem;

--- a/src/components/common/MonthPicker/PickerItemList.module.scss
+++ b/src/components/common/MonthPicker/PickerItemList.module.scss
@@ -1,0 +1,5 @@
+.container {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 18px;
+}

--- a/src/components/common/MonthPicker/PickerItemList.module.scss
+++ b/src/components/common/MonthPicker/PickerItemList.module.scss
@@ -1,5 +1,5 @@
 .container {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 18px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
 }

--- a/src/components/common/MonthPicker/PickerItemList.tsx
+++ b/src/components/common/MonthPicker/PickerItemList.tsx
@@ -11,7 +11,13 @@ interface PickerItemListProps {
   selectedOption: (YearString | MonthString);
   onSelect: (arg1: YearString | MonthString) => void;
 }
-
+/**
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param optionList {(YearString | MonthString)[]} 월 선택창에 들어갈 연 또는 월 리스트
+ * @param selectedOption {YearString | MonthString} 현재 선택된 연, 월 아이템 텍스트("2023", "01" 포맷)
+ * @param onSelect {Function} 각 옵션에 prop으로 전달될 선택 시 호출할 콜백함수
+ * @returns
+ */
 const PickerItemList = ({ optionList, selectedOption, onSelect }: PickerItemListProps) => {
   return (
     <ul className={cx("container")}>

--- a/src/components/common/MonthPicker/PickerItemList.tsx
+++ b/src/components/common/MonthPicker/PickerItemList.tsx
@@ -1,0 +1,32 @@
+import classNames from "classnames/bind";
+
+import { MonthString, YearString } from "./MonthPicker.type";
+import PickerItem from "./PickerItem";
+import styles from "./PickerItemList.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface PickerItemListProps {
+  optionList: (YearString | MonthString)[];
+  selectedOption: (YearString | MonthString);
+  onSelect: (arg1: YearString | MonthString) => void;
+}
+
+const PickerItemList = ({ optionList, selectedOption, onSelect }: PickerItemListProps) => {
+  return (
+    <ul className={cx("container")}>
+      {optionList.map((option) => {
+        return (
+          <PickerItem
+            key={option}
+            onSelect={onSelect}
+            selected={option === selectedOption}
+            textContent={option}
+          />
+        );
+      })}
+    </ul>
+  );
+};
+
+export default PickerItemList;

--- a/src/components/common/Popover/Popover.tsx
+++ b/src/components/common/Popover/Popover.tsx
@@ -62,8 +62,11 @@ const Popover = React.memo(({
         left: `${left ?? "auto"}`,
         right: `${right ?? "auto"}`,
         bottom: `${bottom ?? "auto"}`,
+        cursor: "default",
       }}
       ref={popoverRef}
+      role="presentation"
+      onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
     >
       {children}
     </div>

--- a/src/components/common/Popover/__tests__/Popover.test.tsx
+++ b/src/components/common/Popover/__tests__/Popover.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import Popover from "@/components/common/Popover/Popover";
+import { delay } from "@/utils/test.utils";
 
 describe("팝오버 컴포넌트 렌더링 테스트", () => {
   it("should render properly", () => {
@@ -12,7 +13,7 @@ describe("팝오버 컴포넌트 렌더링 테스트", () => {
     );
     expect(screen.getByText(/팝오버 컨텐츠/i)).toBeInTheDocument();
   });
-  it("should close when clicked outside", () => {
+  it("should close when clicked outside", async () => {
     const handleClose = jest.fn();
     const handleClickOutside = jest.fn();
     render(
@@ -24,6 +25,7 @@ describe("팝오버 컴포넌트 렌더링 테스트", () => {
       </>,
     );
     fireEvent.click(screen.getByText(/외부 영역/i));
+    await delay(100);
     expect(handleClose).toBeCalledTimes(1);
   });
 });

--- a/src/constants/monthPicker.ts
+++ b/src/constants/monthPicker.ts
@@ -1,0 +1,12 @@
+import { MonthString, YearString } from "@/components/common/MonthPicker/MonthPicker.type";
+
+const currentDate = new Date();
+const CURRENT_YEAR = currentDate.getFullYear();
+
+export const YEAR_OPTIONS = Array.from({ length: 9 }, (_, index) => {
+  return (CURRENT_YEAR - 8) + index;
+}).map((year) => { return year.toString() as YearString; });
+
+export const MONTH_OPTIONS:MonthString[] = [
+  "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12",
+];

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -8,10 +8,9 @@ const useOutsideClick = (
 ) => {
   const handleClick = (e: MouseEvent) => {
     if (ref.current && !ref.current.contains(e.target as Node)) {
-      callback();
+      setTimeout(callback, 10);
     }
   };
-
   useEffect(() => {
     document.addEventListener("click", handleClick, { capture: true });
     return () => {

--- a/src/pages/kennytest/[month]/index.page.tsx
+++ b/src/pages/kennytest/[month]/index.page.tsx
@@ -21,7 +21,10 @@ const KennyTestPage = ({ params } : { params: string }) => {
   // eslint-disable-next-line no-console
   console.log(router.query.month);
   return (
-    <div>
+    <div style={{
+      height: "100vh", display: "flex", justifyContent: "center", marginTop: "50px",
+    }}
+    >
       <MonthPickerDropdown />
     </div>
 

--- a/src/pages/kennytest/[month]/index.page.tsx
+++ b/src/pages/kennytest/[month]/index.page.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
+
+import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  // eslint-disable-next-line no-console
+  console.log(context.params);
+  return {
+    props: { params: context.params },
+  };
+};
+
+const KennyTestPage = ({ params } : { params: string }) => {
+  // eslint-disable-next-line no-console
+  console.log(params);
+  const router = useRouter();
+  // eslint-disable-next-line no-console
+  console.log(router.query.month);
+  return (
+    <div>
+      <MonthPickerDropdown />
+    </div>
+
+  );
+};
+
+export default KennyTestPage;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,5 +1,5 @@
 import {
-  AnyAction, CombinedState, Reducer, Store, combineReducers, configureStore,
+  AnyAction, CombinedState, PreloadedState, Reducer, Store, combineReducers, configureStore,
 } from "@reduxjs/toolkit";
 import { HYDRATE, createWrapper } from "next-redux-wrapper";
 
@@ -33,9 +33,10 @@ const createStore = () => {
   return store;
 };
 
-export const setupStore = () => {
+export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
   return configureStore({
     reducer: rootReducer as Reducer<IState, AnyAction>,
+    preloadedState,
     middleware: (getDefaultMiddleware) => {
       return getDefaultMiddleware({ serializableCheck: false });
     },

--- a/src/utils/getLastSegmentFromUrl.ts
+++ b/src/utils/getLastSegmentFromUrl.ts
@@ -1,0 +1,6 @@
+const getLastSegmentFromUrl = (url: string) => {
+  const segments = url.split("/");
+  return segments[segments.length - 1];
+};
+
+export default getLastSegmentFromUrl;

--- a/src/utils/getMonthFromUrl.ts
+++ b/src/utils/getMonthFromUrl.ts
@@ -1,0 +1,7 @@
+import getLastSegmentFromUrl from "./getLastSegmentFromUrl";
+
+const getMonthFromUrl = (url: string) => {
+  return getLastSegmentFromUrl(url).slice(4, 6);
+};
+
+export default getMonthFromUrl;

--- a/src/utils/getParentPathFromUrl.ts
+++ b/src/utils/getParentPathFromUrl.ts
@@ -1,0 +1,9 @@
+const getParentPathFromUrl = (url: string) => {
+  const lastSlashIndex = url.lastIndexOf("/");
+  if (lastSlashIndex === -1) {
+    return null;
+  }
+  return url.substring(0, lastSlashIndex);
+};
+
+export default getParentPathFromUrl;

--- a/src/utils/getYearFromUrl.ts
+++ b/src/utils/getYearFromUrl.ts
@@ -1,0 +1,7 @@
+import getLastSegmentFromUrl from "./getLastSegmentFromUrl";
+
+const getYearFromUrl = (url: string) => {
+  return getLastSegmentFromUrl(url).slice(0, 4);
+};
+
+export default getYearFromUrl;

--- a/src/utils/test.utils.tsx
+++ b/src/utils/test.utils.tsx
@@ -30,3 +30,9 @@ export const renderWithProviders = (
   // Return an object with the store and all of RTL's query functions
   return { store, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 };
+
+export const delay = async (ms: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- MonthPicker 컴포넌트를 추가했습니다.
- useOutsideClick 동작과 Popover 컴포넌트 여닫는 동작 관련해서 의도대로 열리고 닫히지 않는 버그를 수정했습니다. 
- pathname에서 선택된 월을 추출하는 것과 관련된 유틸함수들을 다수 추가했습니다. 
- MonthPicker와 함께 동반되는 작은 컴포넌트들을 추가했습니다. 

### How it Works
<!-- 간단한 로직 설명 -->
- url에 년,월이 마지막에 포함되는 대시보드 페이지들 내에서 MonthPicker를 렌더링하기만 하면 알아서 UI가 나오고, 팝오버 내부에서 년, 월을 선택하고 버튼을 누르면 버튼이 선택된 연, 월을 감지하여 동적인 href를 가진 링크로 동작하게 됩니다.  

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
- 아직 MonthPicker내부에 disable시킬 연, 월을 판단하는 로직은 추가하지 않았습니다.
- url을 수동으로 이상한 월(예시: 111111111)로 바꾸는 경우 예외처리 로직은 추가되어있지 않습니다.
- 아무래도 내부적인 컴포넌트가 많다보니 PR이 많이 큽니다. 양해바랍니다 ㅜㅜ 
- div에 onclick 핸들러를 피하려다 보니 버튼 안에 버튼 엘리먼트가 위치해서 아래 에러가 발생하는데, 우선은 그냥 두었습니다
<img width="902" alt="image" src="https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/11445b71-0387-4ee2-97ac-cdf1d10a8776">
