### PR TITLE
BPS-118/아트보드, 섹션 구분선 레이아웃 컴포넌트 제작

### DIFF
--- a/src/components/common/Layouts/ArtboardLayout.module.scss
+++ b/src/components/common/Layouts/ArtboardLayout.module.scss
@@ -1,0 +1,8 @@
+.board {
+  width: 100%;
+  padding-top: 32px;
+  padding-bottom: 50px;
+  border: 1px solid $sub-color1;
+  border-radius: 6px;
+  background-color: $primary-white;
+}

--- a/src/components/common/Layouts/ArtboardLayout.module.scss
+++ b/src/components/common/Layouts/ArtboardLayout.module.scss
@@ -1,4 +1,6 @@
 .board {
+  @include flexbox(column, flex-start, center);
+
   width: 100%;
   padding-top: 32px;
   padding-bottom: 50px;

--- a/src/components/common/Layouts/ArtboardLayout.tsx
+++ b/src/components/common/Layouts/ArtboardLayout.tsx
@@ -4,6 +4,13 @@ import styles from "./ArtboardLayout.module.scss";
 
 const cx = classNames.bind(styles);
 
+/**
+ * #### 섹션을 감싸는 흰 바탕의 아트보드 레이아웃입니다. 아트보드의 위, 아래 패딩이 적용되어 있습니다.
+ *
+ * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
+ * @param {React.ReactNode} children - 레이아웃의 내용 컴포넌트입니다.
+ *
+ */
 const ArtboardLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className={cx("board")}>

--- a/src/components/common/Layouts/ArtboardLayout.tsx
+++ b/src/components/common/Layouts/ArtboardLayout.tsx
@@ -1,0 +1,15 @@
+import classNames from "classnames/bind";
+
+import styles from "./ArtboardLayout.module.scss";
+
+const cx = classNames.bind(styles);
+
+const ArtboardLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className={cx("board")}>
+      {children}
+    </div>
+  );
+};
+
+export default ArtboardLayout;

--- a/src/components/common/Layouts/SectionHr.module.scss
+++ b/src/components/common/Layouts/SectionHr.module.scss
@@ -1,0 +1,11 @@
+.hr {
+  width: 100%;
+  height: 1px;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  background-color: $sub-color1;
+
+  &.isThick {
+    height: 10px;
+  }
+}

--- a/src/components/common/Layouts/SectionHr.tsx
+++ b/src/components/common/Layouts/SectionHr.tsx
@@ -1,0 +1,21 @@
+import classNames from "classnames/bind";
+
+import styles from "./SectionHr.module.scss";
+
+const cx = classNames.bind(styles);
+
+/**
+ * #### 섹션 간의 구분선입니다. 구분선 위, 아래 마진이 적용되어 있습니다.
+ *
+ * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
+ * @param {boolean} isThick - 두꺼운 구분선인지 여부를 나타냅니다. 기본값은 false입니다.
+ * isThick을 주지 않을 시 1px, isThick을 주면 10px의 구분선이 생깁니다.
+ *
+ */
+const SectionHr = ({ isThick = false }: { isThick?: boolean }) => {
+  return (
+    <hr className={cx("hr", { isThick })} />
+  );
+};
+
+export default SectionHr;

--- a/src/components/common/Layouts/SectionLayout.module.scss
+++ b/src/components/common/Layouts/SectionLayout.module.scss
@@ -1,7 +1,6 @@
 .container {
   @include flexbox(column);
 
-  // margin: 32px auto 50px; (디자이너님과 협의 후 결정)
   width: 100%;
   gap: 32px;
 

--- a/src/components/layout/SideNav/SideNav.module.scss
+++ b/src/components/layout/SideNav/SideNav.module.scss
@@ -1,5 +1,5 @@
 .asideContainer {
-  position: sticky;
+  position: fixed;
   width: 250px;
   height: calc(100vh - 89px);
   padding: 32px 30px 0;

--- a/src/components/layout/SideNav/SideNav.tsx
+++ b/src/components/layout/SideNav/SideNav.tsx
@@ -29,14 +29,14 @@ const SideNav = ({ isOpen, setIsOpen, type }: SideNavProps) => {
   }, [type]);
 
   return (
-    <div className="app">
+    <>
       <aside className={cx("asideContainer")}>
         {sideNavList?.map((list) => {
           return <Link className={cx("asideItem", router.pathname === list.path && "active")} key={list.id} href={list.path}>{list.content}</Link>;
         })}
       </aside>
       <SideNavMobile sideNavList={sideNavList} isOpen={isOpen} setIsOpen={setIsOpen} />
-    </div>
+    </>
   );
 };
 

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -31,7 +31,7 @@ const App = ({ Component, ...rest }: AppProps) => {
       <Head>
         <title>블루키뮤직 정산시스템</title>
       </Head>
-      <main className={Pretendard.className}>
+      <main className={Pretendard.className} style={{ minWidth: "1920px" }}>
         {getContent()}
       </main>
       <ToastRoot />

--- a/src/pages/ian.page.tsx
+++ b/src/pages/ian.page.tsx
@@ -1,23 +1,22 @@
+import ArtboardLayout from "@/components/common/Layouts/ArtboardLayout";
 import MainLayout from "@/components/common/Layouts/MainLayout";
-import Pagination from "@/components/common/Pagination/Pagination";
-import AdminAccountsTable from "@/components/common/Table/Assemble/AdminAccountsTable";
-import TrackStatusTable from "@/components/common/Table/Assemble/TrackStatusTable";
-import { MOCK_ADMIN_TABLE } from "@/constants/mock";
-import { MOCK_ADMIN_ACCOUNT_DATA } from "@/constants/table";
+import SectionHr from "@/components/common/Layouts/SectionHr";
+import SectionLayout from "@/components/common/Layouts/SectionLayout";
 
 const Ian = () => {
   return (
     <MainLayout title="페이지 레이아웃">
-      <div style={{ width: "100%" }}>
-        <TrackStatusTable
-          data={MOCK_ADMIN_TABLE}
-          paginationElement={<Pagination activePage={15} totalItems={120} itemsPerPage={6} />}
-        />
-        <AdminAccountsTable
-          data={MOCK_ADMIN_ACCOUNT_DATA}
-          paginationElement={<Pagination activePage={10} totalItems={80} itemsPerPage={4} queryParamName="admin-account-page" />}
-        />
-      </div>
+      <ArtboardLayout>
+        <div style={{ width: "730px" }}>
+          <SectionLayout title="위 섹션">
+            <div>위 섹션 내용물</div>
+          </SectionLayout>
+          <SectionHr isThick />
+          <SectionLayout title="아래 섹션">
+            <div>아래 섹션 내용물</div>
+          </SectionLayout>
+        </div>
+      </ArtboardLayout>
     </MainLayout>
   );
 };

--- a/src/pages/ian.page.tsx
+++ b/src/pages/ian.page.tsx
@@ -1,17 +1,14 @@
+import MainLayout from "@/components/common/Layouts/MainLayout";
 import Pagination from "@/components/common/Pagination/Pagination";
 import AdminAccountsTable from "@/components/common/Table/Assemble/AdminAccountsTable";
 import TrackStatusTable from "@/components/common/Table/Assemble/TrackStatusTable";
-import UnRegisteredDataTable from "@/components/common/Table/Assemble/UnRegisteredDataTable";
 import { MOCK_ADMIN_TABLE } from "@/constants/mock";
-import { MOCK_ADMIN_ACCOUNT_DATA, MOCK_UNREGISTERED_DATA } from "@/constants/table";
+import { MOCK_ADMIN_ACCOUNT_DATA } from "@/constants/table";
 
 const Ian = () => {
   return (
-    <>
-      <div style={{
-        maxWidth: "1200px", display: "flex", flexDirection: "column", gap: "50px", marginBottom: "30px",
-      }}
-      >
+    <MainLayout title="페이지 레이아웃">
+      <div style={{ width: "100%" }}>
         <TrackStatusTable
           data={MOCK_ADMIN_TABLE}
           paginationElement={<Pagination activePage={15} totalItems={120} itemsPerPage={6} />}
@@ -21,13 +18,7 @@ const Ian = () => {
           paginationElement={<Pagination activePage={10} totalItems={80} itemsPerPage={4} queryParamName="admin-account-page" />}
         />
       </div>
-      <div style={{
-        maxWidth: "455px", maxHeight: "278px", display: "flex", flexDirection: "column",
-      }}
-      >
-        <UnRegisteredDataTable data={MOCK_UNREGISTERED_DATA} />
-      </div>
-    </>
+    </MainLayout>
   );
 };
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 페이지 전체(`main` 태그)에 `minWidth: 1920px` 적용)
- 사이드 내브의 `position` 속성을 `fixed`로 변경 및 가장 겉을 감싸고 있던 `div(className "app")` 제거
- `ArtboardLayout`(섹션을 감싸는 흰 바탕), `SectionHr`(얇은/두꺼운 선) 제작

### How it Works
<!-- 간단한 로직 설명 -->

- 아트보드: `위, 아래 패딩`을 적용했고, `align-items: center`로 처리해서 내용물이 가운데 위치하게 했습니다.
- 섹션 구분선: `isThick` prop을 선택적으로 받아, isThick을 받지 않으면 `1px`, isThick을 받으면 `10px`의 구분선이 생깁니다.

- 최종적으로 `아트보드가 있는 페이지의 레이아웃`을 구성할 때 사용하는 쪽에서 설정할 부분은 아래에서 `위 섹션, 구분선, 아래 섹션을 감싸는 div`의 `width`라고 보시면 됩니다..!

```
    <MainLayout title="페이지 레이아웃">
      <ArtboardLayout>
        // 이 부분
        <div style={{ width: "730px" }}>
          <SectionLayout title="위 섹션">
            <div>위 섹션 내용물</div>
          </SectionLayout>
          <SectionHr isThick />
          <SectionLayout title="아래 섹션">
            <div>아래 섹션 내용물</div>
          </SectionLayout>
        </div>
      </ArtboardLayout>
    </MainLayout>
```

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/917189df-6c81-4fd6-b5bb-9c7e9ad18683)


### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
