### PR TITLE
BPS-133/전체 레이아웃 스타일링 변경

### DIFF
--- a/src/components/common/Layouts/MainLayout.module.scss
+++ b/src/components/common/Layouts/MainLayout.module.scss
@@ -2,7 +2,7 @@
   @include flexbox(column);
 
   width: 1200px;
-  margin: 38px auto 50px;
+  margin-bottom: 50px;
   gap: 50px;
 
   .title {

--- a/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
+++ b/src/components/common/Layouts/MainLayoutWithDropdown.module.scss
@@ -2,7 +2,7 @@
   @include flexbox(column);
 
   width: 1200px;
-  margin: 32px auto 50px;
+  margin-bottom: 50px;
   gap: 32px;
 
   .titleContainer {

--- a/src/components/common/Table/Composition/TableContainerUI.module.scss
+++ b/src/components/common/Table/Composition/TableContainerUI.module.scss
@@ -6,24 +6,7 @@
   .tableWrapper {
     overflow: auto;
 
-    // 스크롤바 스타일
-    &::-webkit-scrollbar-button {
-      display: none;
-    }
-
-    &::-webkit-scrollbar {
-      width: 5px;
-      height: 5px;
-    }
-
-    &::-webkit-scrollbar-track {
-      background-color: transparent;
-    }
-
-    &::-webkit-scrollbar-thumb {
-      border-radius: 20px;
-      background-color: $sub-color2;
-    }
+    @include scrollbar(5);
 
     .table {
       @include typo(12);
@@ -54,7 +37,6 @@
 
       // Header or Column sticky 여부에 따른 처리
       &.stickyHeader {
-        // color: $point-color-blue4;
         th {
           position: sticky;
           z-index: 1;

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -1,0 +1,11 @@
+.sideContentContainer {
+  display: grid;
+  grid-template-columns: 250px auto;
+
+  .content {
+    width: 100%;
+    padding-top: 38px;
+    padding-left: 110px;
+    overflow-x: scroll;
+  }
+}

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -6,6 +6,8 @@
     width: 100%;
     padding-top: 38px;
     padding-left: 110px;
-    overflow-x: scroll;
+    overflow-x: auto;
+
+    @include scrollbar(15);
   }
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
 
+import classNames from "classnames/bind";
+
 import { useAppSelector } from "@/redux/hooks";
 
 import GNB from "./GNB/GNB";
+import styles from "./Layout.module.scss";
 import SideNav from "./SideNav/SideNav";
+
+const cx = classNames.bind(styles);
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -16,9 +21,11 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
         profileImage={userInfo!.profileImage}
         onClickMenu={setIsOpen}
       />
-      <div style={{ display: "flex", position: "relative" }}>
+      <div className={cx("sideContentContainer")}>
         <SideNav isOpen={isOpen} setIsOpen={setIsOpen} type={userInfo!.type} />
-        {children}
+        <div className={cx("content")}>
+          {children}
+        </div>
       </div>
     </>
   );

--- a/src/components/layout/SideNav/SideNav.module.scss
+++ b/src/components/layout/SideNav/SideNav.module.scss
@@ -1,6 +1,4 @@
 .asideContainer {
-  position: absolute;
-  width: 250px;
   height: max(calc(100vh - 89px), 100%);
   padding: 32px 30px 0;
   border: 1px solid $sub-color2;

--- a/src/components/layout/SideNav/SideNav.module.scss
+++ b/src/components/layout/SideNav/SideNav.module.scss
@@ -1,29 +1,34 @@
 .asideContainer {
   position: absolute;
   width: 250px;
-  height: calc(100vh - 89px);
+  height: max(calc(100vh - 89px), 100%);
   padding: 32px 30px 0;
   border: 1px solid $sub-color2;
   background-color: $primary-white;
 
-  .asideItem {
-    display: block;
-    width: 190px;
-    height: 55px;
-    padding: 18px 30px;
-    border-radius: 0.6px;
-    color: $primary-black;
-    cursor: pointer;
+  .linkContainer {
+    position: sticky;
+    top: 89px;
 
-    &.active {
-      border-radius: 6px;
-      background-color: $point-color-blue1;
-      color: $point-color-blue4;
-    }
+    .asideItem {
+      display: block;
+      width: 190px;
+      height: 55px;
+      padding: 18px 30px;
+      border-radius: 0.6px;
+      color: $primary-black;
+      cursor: pointer;
 
-    &:hover {
-      background-color: $point-color-blue1;
-      color: $point-color-blue4;
+      &.active {
+        border-radius: 6px;
+        background-color: $point-color-blue1;
+        color: $point-color-blue4;
+      }
+
+      &:hover {
+        background-color: $point-color-blue1;
+        color: $point-color-blue4;
+      }
     }
   }
 }

--- a/src/components/layout/SideNav/SideNav.tsx
+++ b/src/components/layout/SideNav/SideNav.tsx
@@ -31,9 +31,15 @@ const SideNav = ({ isOpen, setIsOpen, type }: SideNavProps) => {
   return (
     <>
       <aside className={cx("asideContainer")}>
-        {sideNavList?.map((list) => {
-          return <Link className={cx("asideItem", router.pathname === list.path && "active")} key={list.id} href={list.path}>{list.content}</Link>;
-        })}
+        <ul className={cx("linkContainer")}>
+          {sideNavList?.map((list) => {
+            return (
+              <li key={list.id}>
+                <Link className={cx("asideItem", router.pathname === list.path && "active")} href={list.path}>{list.content}</Link>
+              </li>
+            );
+          })}
+        </ul>
       </aside>
       <SideNavMobile sideNavList={sideNavList} isOpen={isOpen} setIsOpen={setIsOpen} />
     </>

--- a/src/components/layout/SideNav/SideNavMobile.tsx
+++ b/src/components/layout/SideNav/SideNavMobile.tsx
@@ -26,12 +26,18 @@ const SideNavMobile = ({ sideNavList, isOpen, setIsOpen }: SideNavMobileProps) =
     <DynamicDrawer isOpen={isOpen} onClose={() => { return setIsOpen(false); }} removeWhenClosed className="mobile">
       <aside className={cx("asideContainerMobile")}>
         <div className={cx("logoContainer")}>
-          <Image src="/images/mobile-logo.svg" alt="로고" width={172} height={29} />
+          <Image src="/images/bluekey-music-insight-logo.svg" alt="로고" width={172} height={29} />
           <Image src="/images/close.svg" alt="닫기" width={16} height={16} className={cx("close")} onClick={() => { return setIsOpen(!isOpen); }} />
         </div>
-        {sideNavList?.map((list) => {
-          return <Link className={cx("asideItem", router.pathname === list.path && "active")} key={list.id} href={list.path}>{list.content}</Link>;
-        })}
+        <ul>
+          {sideNavList?.map((list) => {
+            return (
+              <li key={list.id}>
+                <Link className={cx("asideItem", router.pathname === list.path && "active")} href={list.path}>{list.content}</Link>
+              </li>
+            );
+          })}
+        </ul>
       </aside>
     </DynamicDrawer>
   );

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -40,7 +40,7 @@ const App = ({ Component, ...rest }: AppProps<{ dehydratedState: DehydratedState
           <Head>
             <title>블루키뮤직 정산시스템</title>
           </Head>
-          <main className={Pretendard.className} style={{ width: "1920px" }}>
+          <main className={Pretendard.className}>
             {getContent()}
           </main>
           <ToastRoot />

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -53,3 +53,24 @@
     @content;
   }
 }
+
+@mixin scrollbar($thickness, $color: #edeef0) {
+  // 기본 색: $sub-color2
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  &::-webkit-scrollbar {
+    width: #{$thickness}px;
+    height: #{$thickness}px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 20px;
+    background-color: $color;
+  }
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -21,7 +21,6 @@ html {
 
 body {
   width: 100%;
-  max-width: 1920px;
   margin: 0 auto;
   background-color: $sub-color4;
   font-size: 16px;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes
1. side nav ul 태그 추가
2. body, main에 있는 max-width: 1920px 삭제
3. side nav의 position 속성을 제거하였고 content와 display: grid로 묶었습니다.
4. side nav는 250px로 고정이며 나머지 영역은 content가 차지하도록 구성하였습니다. 또, content 부분에 padding-top과 padding-left을 설정하여 sideNav와의 영역이 겹치지 않도록 하였습니다. 따라서 기존에 제작된 MainLayout의 margin: 0 auto 부분은 수정이 필요합니다.
5. sidenav는 전체 영역을 차지할 수 있도록 max 함수를 사용하였습니다.

### How it Works


### To Reviewers

