### PR TITLE
BPS-137/대시보드 카드 쿼리 훅 제작

### DIFF
--- a/src/components/dashboard/DashboardCardList/DashboardCardList.tsx
+++ b/src/components/dashboard/DashboardCardList/DashboardCardList.tsx
@@ -9,17 +9,20 @@ const cx = classNames.bind(styles);
 
 const DashboardCardList = ({ data }: { data: DashboardCardProps[] }) => {
   return (
-    <section className={cx("container")}>
-      {data.map((item) => {
-        return (
-          <DashboardCard
-            title={item.title}
-            content={item.content}
-            growthRate={item.growthRate}
-            key={item.title}
-          />
-        );
-      })}
+    <section>
+      <ul className={cx("container")}>
+        {data.map((item) => {
+          return (
+            <li key={item.title}>
+              <DashboardCard
+                title={item.title}
+                content={item.content}
+                growthRate={item.growthRate}
+              />
+            </li>
+          );
+        })}
+      </ul>
     </section>
   );
 };

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -5,6 +5,7 @@ import {
   IGetAdminTrackTransactionResponse,
 } from "@/services/api/types/admin";
 import {
+  IGetAlbumDashboardResponse,
   IGetAlbumMonthlySettlementResponse,
   IGetAlbumRevenueTopTrackResponse,
   IGetAlbumTrackSettlementTrendsResponse,
@@ -277,6 +278,21 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
       proportion: 4,
     },
   ],
+};
+
+export const MOCK_ALBUM_DASHBOARD_CARD: IGetAlbumDashboardResponse = {
+  settlement:
+  {
+    totalAmount: 1000,
+    growthRate: 10.2,
+  },
+  bestTrack:
+  {
+    trackId: 1,
+    koTrackName: "트랙명2",
+    enTrackName: "track2",
+    growthRate: -30,
+  },
 };
 /* ########################## */
 

--- a/src/pages/ian/202308.page.tsx
+++ b/src/pages/ian/202308.page.tsx
@@ -1,21 +1,20 @@
-import { DashboardCardProps } from "@/components/common/DashboardCard/DashboardCard.type";
 import MainLayoutWithDropdown from "@/components/common/Layouts/MainLayoutWithDropdown";
 import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
 import Pagination from "@/components/common/Pagination/Pagination";
 import DashboardCardList from "@/components/dashboard/DashboardCardList/DashboardCardList";
 import TrackStatusTable from "@/components/dashboard/TrackStatusTable/TrackStatusTable";
 import { MOCK_ADMIN_TABLE } from "@/constants/mock";
-import formatMoney from "@/utils/formatMoney";
+import { useDashboardCards } from "@/services/queries/useDashboardCards";
+import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 
 const Ian = () => {
-  const cardsData: DashboardCardProps[] = [
-    { title: "당월 총 매출액", content: formatMoney(1000000, "card"), growthRate: 2.1 },
-    { title: "당월 총 매출액", content: formatMoney(1000000, "card"), growthRate: 2.1 },
-    { title: "당월 총 매출액", content: formatMoney(1000000, "card"), growthRate: 2.1 },
-    { title: "당월 총 매출액", content: formatMoney(1000000, "card"), growthRate: 2.1 },
-  ];
+  const { cardsData, isError, isLoading } = useDashboardCards(DASHBOARD_TYPE.ADMIN);
 
   const { totalItems, contents: tableData } = MOCK_ADMIN_TABLE;
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>에러 발생!</div>;
+  if (!cardsData) return <div>데이터가 없다</div>;
   return (
     <MainLayoutWithDropdown title="대쉬보드" dropdownElement={<MonthPickerDropdown />}>
       <DashboardCardList data={cardsData} />

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -1,5 +1,6 @@
 import {
   IAlbumCard,
+  IAlbumDashboardCard,
   IAlbumInfo,
   IBarMonthlySettlement,
   IDoughnutTrackRevenue,
@@ -9,6 +10,9 @@ import {
 export interface IGetAlbumsResponse {
   totalItems: number,
   contents: IAlbumCard[]
+}
+
+export interface IGetAlbumDashboardResponse extends IAlbumDashboardCard {
 }
 
 export interface IGetAlbumTracksResponse extends IAlbumInfo {

--- a/src/services/queries/useDashboardCards.ts
+++ b/src/services/queries/useDashboardCards.ts
@@ -35,7 +35,7 @@ const getAlbumDashboardCards = (): Promise<IGetAlbumDashboardResponse> => {
   });
 };
 
-const getDashboardCards = async (type: DashboardType, yearMonthStr: string) => {
+export const getDashboardCards = async (type: DashboardType, yearMonthStr: string) => {
   let response;
   let data: DashboardCardProps[];
   if (type === DASHBOARD_TYPE.ADMIN) {

--- a/src/services/queries/useDashboardCards.ts
+++ b/src/services/queries/useDashboardCards.ts
@@ -1,0 +1,113 @@
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+
+import { DashboardCardProps } from "@/components/common/DashboardCard/DashboardCard.type";
+import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthPicker.util";
+import { MOCK_ADMIN_DASHBOARD_CARD, MOCK_ALBUM_DASHBOARD_CARD, MOCK_ARTIST_DASHBOARD_CARD } from "@/constants/mock";
+import { IGetAdminDashboardResponse } from "@/services/api/types/admin";
+import { IGetAlbumDashboardResponse } from "@/services/api/types/albums";
+import { IGetArtistDashboardResponse } from "@/services/api/types/artist";
+import { DASHBOARD_TYPE, DashboardType } from "@/types/enums/dashboard.enum";
+import formatMoney from "@/utils/formatMoney";
+import getLastSegmentFromUrl from "@/utils/getLastSegmentFromUrl";
+
+const getAdminDashboardCards = (): Promise<IGetAdminDashboardResponse> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_ADMIN_DASHBOARD_CARD);
+    }, 2000);
+  });
+};
+
+const getArtistDashboardCards = (): Promise<IGetArtistDashboardResponse> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_ARTIST_DASHBOARD_CARD);
+    }, 2000);
+  });
+};
+
+const getAlbumDashboardCards = (): Promise<IGetAlbumDashboardResponse> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(MOCK_ALBUM_DASHBOARD_CARD);
+    }, 2000);
+  });
+};
+
+const getDashboardCards = async (type: DashboardType, yearMonthStr: string) => {
+  let response;
+  let data: DashboardCardProps[];
+  if (type === DASHBOARD_TYPE.ADMIN) {
+    response = await getAdminDashboardCards();
+    const {
+      revenue, settlementAmount, bestArtist, netIncome,
+    } = response;
+    data = [{
+      title: "당월 총 매출액",
+      content: formatMoney(revenue.totalAmount, "card"),
+      growthRate: revenue.growthRate,
+    },
+    {
+      title: "당월 회사 이익",
+      content: formatMoney(netIncome.totalAmount, "card"),
+      growthRate: netIncome.growthRate,
+    },
+    {
+      title: "당월 총 정산액",
+      content: formatMoney(settlementAmount.totalAmount, "card"),
+      growthRate: settlementAmount.growthRate,
+    },
+    {
+      title: `${yearMonthStr}의 아티스트`,
+      content: bestArtist.koArtistName,
+      growthRate: bestArtist.growthRate,
+    }];
+  } else if (type === DASHBOARD_TYPE.ARTIST) {
+    response = await getArtistDashboardCards();
+    const { bestAlbum, bestTrack, settlement } = response;
+    data = [{
+      title: "당월 정산액",
+      content: formatMoney(settlement.totalAmount, "card"),
+      growthRate: settlement.growthRate,
+    },
+    {
+      title: `${yearMonthStr}의 앨범`,
+      content: bestAlbum.koAlbumName,
+      growthRate: bestAlbum.growthRate,
+    },
+    {
+      title: `${yearMonthStr}의 트랙`,
+      content: bestTrack.koTrackName,
+      growthRate: bestTrack.growthRate,
+    }];
+  } else {
+    response = await getAlbumDashboardCards();
+    const { settlement, bestTrack } = response;
+    data = [{
+      title: "이 앨범의 당월 정산액",
+      content: formatMoney(settlement.totalAmount, "card"),
+      growthRate: settlement.growthRate,
+    },
+    {
+      title: `${yearMonthStr}의 트랙`,
+      content: bestTrack.koTrackName,
+      growthRate: bestTrack.growthRate,
+    }];
+  }
+
+  return data;
+};
+
+export function useDashboardCards(type: DashboardType) {
+  const router = useRouter();
+  const yearMonthStr = convertToYearMonthFormat(getLastSegmentFromUrl(router.asPath));
+  const { data: cardsData, isError, isLoading } = useQuery(
+    [type, "dashboard", "card"],
+    () => { return getDashboardCards(type, yearMonthStr); },
+  );
+
+  return ({
+    cardsData, isLoading, isError,
+  });
+}

--- a/src/services/queries/useDashboardCards.ts
+++ b/src/services/queries/useDashboardCards.ts
@@ -105,6 +105,9 @@ export function useDashboardCards(type: DashboardType) {
   const { data: cardsData, isError, isLoading } = useQuery(
     [type, "dashboard", "card"],
     () => { return getDashboardCards(type, yearMonthStr); },
+    {
+      staleTime: 5000,
+    },
   );
 
   return ({

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -123,8 +123,6 @@ export interface IArtistDashboardCard {
 }
 
 export interface IAlbumDashboardCard {
-  koAlbumName: string,
-  enAlbumName: string,
   settlement: IEarnings
   bestTrack: ITrack & {
     growthRate: number | null

--- a/src/types/enums/dashboard.enum.ts
+++ b/src/types/enums/dashboard.enum.ts
@@ -1,0 +1,10 @@
+export const DASHBOARD_TYPE = {
+  ADMIN: "ADMIN",
+  ARTIST: "ARTIST",
+  ALBUM: "ALBUM",
+} as const;
+
+export type DashboardType = (typeof DASHBOARD_TYPE)[keyof typeof DASHBOARD_TYPE];
+export type AdminDashboardType = (typeof DASHBOARD_TYPE)["ADMIN"];
+export type ArtistDashboardType = (typeof DASHBOARD_TYPE)["ARTIST"];
+export type AlbumDashboardType = (typeof DASHBOARD_TYPE)["ALBUM"];


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 대시보드용 타입 제작(`ADMIN, ARTIST, ALBUM`)
- 앨범 대시보드 api response & mock 제작 (스웨거에 누락있었음)
- `useDashboardCards` 쿼리 훅 제작
- 테스트 페이지에 쿼리 훅 및 SSR 적용

### How it Works
<!-- 간단한 로직 설명 -->

- 쿼리 훅을 만들어서 테스트 페이지에 적용해봤고, `SSR`도 같이 적용해봤습니다~!
- 페이지(ex. `/ian/202308`)에 들어갈 때 서버에서 fetch가 되고, `staleTime`을 `5000`로 설정해놔서 `5초 동안 fresh`가 유지되는 것도 볼 수 있습니다!

- DASHBOARD_TYPE.ADMIN
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/6a660699-6c4d-4096-83cc-08b77647851a)

- DASHBOARD_TYPE.ARTIST
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/82475dfc-1777-4520-b636-b4dcf6e34e07)

- DASHBOARD_TYPE.ALBUM
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/9805e9f6-fdfa-4ee0-9f8e-dad5e90e7c16)

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->

- 쿼리 훅에 대해서 피드백 주시면 감사하겠습니당
- 쿼리키를 어떻게 설정할지에 대해서 내일 얘기해보면 좋을 것 같슴다!
- 저는 다음 단계로 GET이 실패하면 거진 에러 페이지로 던져질 것 같으니 useQuery 에러 핸들링을 전역적으로 만들어보기 (+ 덤으로 에러, 404 페이지를 만들 수도) / 테이블 쿼리 훅 만들기 를 할 예정입니다~!!