### PR TITLE
BPS-146/정산 내역 테이블 컴포넌트 제작

### DIFF
--- a/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
+++ b/src/components/common/MonthPicker/MonthPickerDropdown.module.scss
@@ -1,5 +1,6 @@
 .container {
   position: relative;
+  z-index: 2;
   width: 139px;
   height: 40px;
   padding: 12px 20px;

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -12,7 +12,7 @@ import useToast from "@/hooks/useToast";
 import { ITransactionUpload } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
-interface FileDataProps {
+interface FileData {
   fileId: number,
   fileName: string
 }
@@ -21,7 +21,7 @@ const UploadHistroyTable = (
   { uploadList }: { uploadList: ITransactionUpload[] },
 ) => {
   const [isCancelUploadModalOpen, setIsCancelUploadModalOpen] = useState(false);
-  const [fileData, setFileData] = useState<FileDataProps>({} as FileDataProps);
+  const [fileData, setFileData] = useState<FileData>({} as FileData);
   const { showToast } = useToast();
 
   const handleClickCancelUploadBtn = (fileId: number, fileName: string) => {

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -48,7 +48,7 @@ const UploadHistroyTable = (
   return (
     <>
       <TableContainerUI
-        stickyFirstCol
+        stickyLastCol
         tableWidth={730}
       >
         <TableHeaderUI>

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -8,6 +8,7 @@ import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
+import useToast from "@/hooks/useToast";
 import { ITransactionUpload } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
@@ -21,6 +22,7 @@ const UploadHistroyTable = (
 ) => {
   const [isCancelUploadModalOpen, setIsCancelUploadModalOpen] = useState(false);
   const [fileData, setFileData] = useState<FileDataProps>({} as FileDataProps);
+  const { showToast } = useToast();
 
   const handleClickCancelUploadBtn = (fileId: number, fileName: string) => {
     setIsCancelUploadModalOpen(true);
@@ -30,11 +32,13 @@ const UploadHistroyTable = (
     });
   };
 
-  // TODO: 업로드 취소 API 작업
   const handleCancelUpload = (fileId: number, fileName: string) => {
+    // TODO: 업로드 취소 API 작업
     // eslint-disable-next-line no-console
     console.log(`(${fileId}) ${fileName} 파일 삭제`);
+
     setIsCancelUploadModalOpen(false);
+    showToast("업로드 내역이 삭제되었습니다.");
   };
 
   if (uploadList.length === 0) {

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -1,0 +1,44 @@
+import ChipButton from "@/components/common/CommonBtns/ChipButton/ChipButton";
+import TableBodyUI from "@/components/common/Table/Composition/TableBodyUI";
+import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
+import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
+import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
+import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
+import { MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
+import { ITransactionUpload } from "@/types/dto";
+
+const UploadHistroyTable = (
+  { uploadList = MOCK_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
+) => {
+  return (
+    <TableContainerUI
+      stickyFirstCol
+      tableWidth={730}
+    >
+      <TableHeaderUI>
+        <TableCellUI isHeader>파일명</TableCellUI>
+        <TableCellUI isHeader>업로드 날짜</TableCellUI>
+        <TableCellUI isHeader>비고</TableCellUI>
+      </TableHeaderUI>
+      <TableBodyUI>
+        {uploadList.map((item) => {
+          return (
+            <TableRowUI key={item.id}>
+              <TableCellUI>
+                <p>{item.name}</p>
+              </TableCellUI>
+              <TableCellUI>
+                <p>{item.uploadAt}</p>
+              </TableCellUI>
+              <TableCellUI>
+                <ChipButton>업로드 취소</ChipButton>
+              </TableCellUI>
+            </TableRowUI>
+          );
+        })}
+      </TableBodyUI>
+    </TableContainerUI>
+  );
+};
+
+export default UploadHistroyTable;

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -8,7 +8,6 @@ import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
-import { MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
 import { ITransactionUpload } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
@@ -18,17 +17,24 @@ interface FileDataProps {
 }
 
 const UploadHistroyTable = (
-  { uploadList = MOCK_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
+  { uploadList }: { uploadList: ITransactionUpload[] },
 ) => {
-  const [modalOpen, setModalOpen] = useState(false);
-  const [fileData, setFileData] = useState<FileDataProps | null>(null);
+  const [isCancelUploadModalOpen, setIsCancelUploadModalOpen] = useState(false);
+  const [fileData, setFileData] = useState<FileDataProps>({} as FileDataProps);
 
-  const handleClickCancelUpload = (fileId: number, fileName: string) => {
-    setModalOpen(true);
+  const handleClickCancelUploadBtn = (fileId: number, fileName: string) => {
+    setIsCancelUploadModalOpen(true);
     setFileData({
       fileId,
       fileName,
     });
+  };
+
+  // TODO: 업로드 취소 API 작업
+  const handleCancelUpload = (fileId: number, fileName: string) => {
+    // eslint-disable-next-line no-console
+    console.log(`(${fileId}) ${fileName} 파일 삭제`);
+    setIsCancelUploadModalOpen(false);
   };
 
   if (uploadList.length === 0) {
@@ -58,7 +64,7 @@ const UploadHistroyTable = (
                 </TableCellUI>
                 <TableCellUI>
                   <ChipButton onClick={() => {
-                    return handleClickCancelUpload(item.id, item.name);
+                    return handleClickCancelUploadBtn(item.id, item.name);
                   }}
                   >
                     업로드 취소
@@ -70,18 +76,18 @@ const UploadHistroyTable = (
         </TableBodyUI>
       </TableContainerUI>
       <AlertModal
-        open={modalOpen}
+        open={isCancelUploadModalOpen}
         type={MODAL_TYPE.CONFIRM}
         title="업로드 내역 삭제"
         message={`파일 ${fileData?.fileName}의 업로드 내역을 삭제하시겠습니까?`}
-        onClose={() => { setModalOpen(false); }}
-        // eslint-disable-next-line no-console
-        onClickProceed={() => { console.log(fileData?.fileId, fileData?.fileName); }}
+        onClose={() => { setIsCancelUploadModalOpen(false); }}
+        onClickProceed={() => {
+          return handleCancelUpload(fileData.fileId, fileData.fileName);
+        }}
         proceedBtnText="네, 삭제할게요"
         closeBtnText="아니요"
       />
     </>
-
   );
 };
 

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -1,48 +1,87 @@
+import { useState } from "react";
+
 import ChipButton from "@/components/common/CommonBtns/ChipButton/ChipButton";
 import EmptyData from "@/components/common/EmptyData/EmptyData";
+import AlertModal from "@/components/common/Modals/AlertModal/AlertModal";
 import TableBodyUI from "@/components/common/Table/Composition/TableBodyUI";
 import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
-import { MOCK_EMPTY_TRANSACTION_UPLOAD, MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
+import { MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
 import { ITransactionUpload } from "@/types/dto";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+
+interface FileDataProps {
+  fileId: number,
+  fileName: string
+}
 
 const UploadHistroyTable = (
-  { uploadList = MOCK_EMPTY_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
+  { uploadList = MOCK_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
 ) => {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [fileData, setFileData] = useState<FileDataProps | null>(null);
+
+  const handleClickCancelUpload = (fileId: number, fileName: string) => {
+    setModalOpen(true);
+    setFileData({
+      fileId,
+      fileName,
+    });
+  };
+
   if (uploadList.length === 0) {
     return <EmptyData type="no-data" text="업로드 내역이 없습니다." />;
   }
 
   return (
-    <TableContainerUI
-      stickyFirstCol
-      tableWidth={730}
-    >
-      <TableHeaderUI>
-        <TableCellUI isHeader>파일명</TableCellUI>
-        <TableCellUI isHeader>업로드 날짜</TableCellUI>
-        <TableCellUI isHeader>비고</TableCellUI>
-      </TableHeaderUI>
-      <TableBodyUI>
-        {uploadList.map((item) => {
-          return (
-            <TableRowUI key={item.id}>
-              <TableCellUI>
-                <p>{item.name}</p>
-              </TableCellUI>
-              <TableCellUI>
-                <p>{item.uploadAt}</p>
-              </TableCellUI>
-              <TableCellUI>
-                <ChipButton>업로드 취소</ChipButton>
-              </TableCellUI>
-            </TableRowUI>
-          );
-        })}
-      </TableBodyUI>
-    </TableContainerUI>
+    <>
+      <TableContainerUI
+        stickyFirstCol
+        tableWidth={730}
+      >
+        <TableHeaderUI>
+          <TableCellUI isHeader>파일명</TableCellUI>
+          <TableCellUI isHeader>업로드 날짜</TableCellUI>
+          <TableCellUI isHeader>비고</TableCellUI>
+        </TableHeaderUI>
+        <TableBodyUI>
+          {uploadList.map((item) => {
+            return (
+              <TableRowUI key={item.id}>
+                <TableCellUI>
+                  <p>{item.name}</p>
+                </TableCellUI>
+                <TableCellUI>
+                  <p>{item.uploadAt}</p>
+                </TableCellUI>
+                <TableCellUI>
+                  <ChipButton onClick={() => {
+                    return handleClickCancelUpload(item.id, item.name);
+                  }}
+                  >
+                    업로드 취소
+                  </ChipButton>
+                </TableCellUI>
+              </TableRowUI>
+            );
+          })}
+        </TableBodyUI>
+      </TableContainerUI>
+      <AlertModal
+        open={modalOpen}
+        type={MODAL_TYPE.CONFIRM}
+        title="업로드 내역 삭제"
+        message={`파일 ${fileData?.fileName}의 업로드 내역을 삭제하시겠습니까?`}
+        onClose={() => { setModalOpen(false); }}
+        // eslint-disable-next-line no-console
+        onClickProceed={() => { console.log(fileData?.fileId, fileData?.fileName); }}
+        proceedBtnText="네, 삭제할게요"
+        closeBtnText="아니요"
+      />
+    </>
+
   );
 };
 

--- a/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
+++ b/src/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable.tsx
@@ -1,15 +1,20 @@
 import ChipButton from "@/components/common/CommonBtns/ChipButton/ChipButton";
+import EmptyData from "@/components/common/EmptyData/EmptyData";
 import TableBodyUI from "@/components/common/Table/Composition/TableBodyUI";
 import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
-import { MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
+import { MOCK_EMPTY_TRANSACTION_UPLOAD, MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
 import { ITransactionUpload } from "@/types/dto";
 
 const UploadHistroyTable = (
-  { uploadList = MOCK_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
+  { uploadList = MOCK_EMPTY_TRANSACTION_UPLOAD.contents }: { uploadList?: ITransactionUpload[] },
 ) => {
+  if (uploadList.length === 0) {
+    return <EmptyData type="no-data" text="업로드 내역이 없습니다." />;
+  }
+
   return (
     <TableContainerUI
       stickyFirstCol

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -288,16 +288,49 @@ export const MOCK_TRANSACTION_UPLOAD: IGETTransactionUploadResponse = {
       id: 1,
       name: "202308_마피아 유통사 정산 내역.xlsx",
       uploadAt: "2023/08/12 13:20",
+      warnings: [
+        {
+          rowIndex: 15,
+          columnIndex: 4,
+          columnName: "앨범명",
+          cellValue: "0.0",
+          type: "NULL_CELL",
+          severity: "string",
+          message: "값이 비어 있는 셀입니다.",
+        },
+      ],
     },
     {
       id: 2,
       name: "202308_아토 유통사 정산 내역.xlsx",
       uploadAt: "2023/08/13 19:00",
+      warnings: [
+        {
+          rowIndex: 15,
+          columnIndex: 4,
+          columnName: "앨범명",
+          cellValue: "0.0",
+          type: "NULL_CELL",
+          severity: "string",
+          message: "값이 비어 있는 셀입니다.",
+        },
+      ],
     },
     {
       id: 3,
       name: "202308_삼쩜일사 유통사 정산 내역.xlsx",
       uploadAt: "2023/08/25 11:03",
+      warnings: [
+        {
+          rowIndex: 15,
+          columnIndex: 4,
+          columnName: "앨범명",
+          cellValue: "0.0",
+          type: "NULL_CELL",
+          severity: "string",
+          message: "값이 비어 있는 셀입니다.",
+        },
+      ],
     },
   ],
 };

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -282,12 +282,22 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
 
 /* ##### 2. TRANSACTION ##### */
 export const MOCK_TRANSACTION_UPLOAD: IGETTransactionUploadResponse = {
-  totalItems: 10,
+  totalItems: 3,
   contents: [
     {
       id: 1,
-      name: "1202306_마피아 유통사 정산 내역.xlsx",
-      uploadAt: "2023-08",
+      name: "202308_마피아 유통사 정산 내역.xlsx",
+      uploadAt: "2023/08/12 13:20",
+    },
+    {
+      id: 2,
+      name: "202308_아토 유통사 정산 내역.xlsx",
+      uploadAt: "2023/08/13 19:00",
+    },
+    {
+      id: 3,
+      name: "202308_삼쩜일사 유통사 정산 내역.xlsx",
+      uploadAt: "2023/08/25 11:03",
     },
   ],
 };

--- a/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
+++ b/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
@@ -1,6 +1,5 @@
 // import { useRouter } from "next/router";
 
-import EmptyData from "@/components/common/EmptyData/EmptyData";
 import ExcelFileUploader from "@/components/common/ExcelFileUploader/ExcelFileUploader";
 import ArtboardLayout from "@/components/common/Layouts/ArtboardLayout";
 import MainLayoutWithDropdown from "@/components/common/Layouts/MainLayoutWithDropdown";
@@ -24,7 +23,6 @@ const UploadRevenuePage = () => {
           </SectionLayout>
           <SectionHr isThick />
           <SectionLayout title="업로드 내역">
-            {/* <EmptyData type="no-data" text="업로드 내역이 없습니다." /> */}
             <UploadHistroyTable />
           </SectionLayout>
         </div>

--- a/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
+++ b/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
@@ -7,6 +7,7 @@ import SectionHr from "@/components/common/Layouts/SectionHr";
 import SectionLayout from "@/components/common/Layouts/SectionLayout";
 import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
 import UploadHistroyTable from "@/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable";
+import { MOCK_TRANSACTION_UPLOAD } from "@/constants/mock";
 
 const UploadRevenuePage = () => {
   return (
@@ -23,7 +24,7 @@ const UploadRevenuePage = () => {
           </SectionLayout>
           <SectionHr isThick />
           <SectionLayout title="업로드 내역">
-            <UploadHistroyTable />
+            <UploadHistroyTable uploadList={MOCK_TRANSACTION_UPLOAD.contents} />
           </SectionLayout>
         </div>
       </ArtboardLayout>

--- a/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
+++ b/src/pages/admin/upload-revenue/[[...monthYear]].page.tsx
@@ -7,6 +7,7 @@ import MainLayoutWithDropdown from "@/components/common/Layouts/MainLayoutWithDr
 import SectionHr from "@/components/common/Layouts/SectionHr";
 import SectionLayout from "@/components/common/Layouts/SectionLayout";
 import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
+import UploadHistroyTable from "@/components/uploadRevenue/UploadHistoryTable/UploadHistoryTable";
 
 const UploadRevenuePage = () => {
   return (
@@ -23,7 +24,8 @@ const UploadRevenuePage = () => {
           </SectionLayout>
           <SectionHr isThick />
           <SectionLayout title="업로드 내역">
-            <EmptyData type="no-data" text="업로드 내역이 없습니다." />
+            {/* <EmptyData type="no-data" text="업로드 내역이 없습니다." /> */}
+            <UploadHistroyTable />
           </SectionLayout>
         </div>
       </ArtboardLayout>

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -166,7 +166,7 @@ export interface IArtistProfile extends IProfile {
 }
 
 // 정산액 업로드 관련
-interface ITransactionUploadWarning {
+interface ITransactionUploadAlert {
   "rowIndex": number,
   "columnIndex": number,
   "columnName": string,
@@ -181,5 +181,5 @@ export interface ITransactionUpload {
   id: number,
   name: string,
   uploadAt: string
-  warnings: ITransactionUploadWarning[]
+  warnings: ITransactionUploadAlert[]
 }

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -166,9 +166,20 @@ export interface IArtistProfile extends IProfile {
 }
 
 // 정산액 업로드 관련
+interface ITransactionUploadWarning {
+  "rowIndex": number,
+  "columnIndex": number,
+  "columnName": string,
+  "cellValue": string,
+  "type": string,
+  "severity": string,
+  "message": string
+}
+
 // /api/v1/transactions
 export interface ITransactionUpload {
   id: number,
   name: string,
   uploadAt: string
+  warnings: ITransactionUploadWarning[]
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
- 업로드 내역 테이블 UI 제작
- 업로드 취소 버튼 클릭 시 삭제 확인 모달을 띄우는 연결 작업
- prop으로 받는 업로드 내역 데이터가 빈 배열일 경우 EmptyData 컴포넌트 렌더링
- MonthPicker 컴포넌트가 테이블에 가려지는 문제가 발생하여 MonthPicker 부분에 z-index를 추가했습니다.

[업로드 내역 테이블 UI]
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/344dfe3a-0c27-4c25-b68e-8a0fdf197f9e)

[업로드 취소 버튼 클릭 시 - 삭제 확인 모달 노출]
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/73c2041f-9ca1-4a88-bfbb-3e4bc1688304)

[삭제 버튼 클릭 시 - 삭제 완료 토스트 노출]
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/eaa02165-428b-4c96-b919-8d980b16cedc)

## 다음 작업
- 업로드 내역 삭제 API / 액셀 파일 업로드 API / 업드로 내역 get API 구현 작업(아직은 mock data로 개발하기 때문에 구색만 갖춰둘 것 같습니다)
- 각 API fetch 시 오류 처리들 생각하기

### To Reviewers
- 가독성을 좋게 하고싶다 보니, 변수 이름들이 긴 감이 없지 않아 있습니다,, 변수나 prop 등의 네이밍 위주로 봐주시면 될 것 같아요!
