### PR TITLE
BPS-171/테이블 배경색, 열 너비 스타일링 수정

### DIFF
--- a/src/components/common/Table/Composition/TableCellUI.tsx
+++ b/src/components/common/Table/Composition/TableCellUI.tsx
@@ -7,7 +7,8 @@ const cx = classNames.bind(styles);
 interface TableCellUIProps {
   children: React.ReactNode
   isHeader?: boolean
-  align?: "center" | "left";
+  align?: "center" | "left"
+  colWidth?: number
 }
 
 /**
@@ -16,14 +17,18 @@ interface TableCellUIProps {
  * @param {boolean} isHeader - `(Optional / Default = false)` 헤더 셀인지 여부를 나타냅니다.
  * @param {"center" | "left"} align - `(Optional / Default = "center")` 셀 내부의 수평 정렬를 나타냅니다.
  * "center" 또는 "left" 값을 가질 수 있습니다.
+ * @param {number} colWidth - `(Optional)` 열의 너비를 지정합니다. 헤더 셀에 isHeader와 함께 전달할 수 있습니다.
+ * colWidth를 전달하지 않은 열들은 너비를 균등하게 나눠 가집니다.
  * @param {React.ReactNode} children - 테이블 내용을 포함한 React 노드입니다.
  * @author 연우킴(drizzle96) [Github](https://github.com/drizzle96)
  */
-const TableCellUI = ({ children, isHeader = false, align = "center" }: TableCellUIProps) => {
+const TableCellUI = ({
+  children, isHeader = false, align = "center", colWidth,
+}: TableCellUIProps) => {
   return (
     isHeader
       ? (
-        <th className={cx("cell", align)}>
+        <th className={cx("cell", align)} style={{ width: colWidth ? `${colWidth}px` : "auto" }}>
           {children}
         </th>
       )

--- a/src/components/common/Table/Composition/TableContainerUI.module.scss
+++ b/src/components/common/Table/Composition/TableContainerUI.module.scss
@@ -45,6 +45,10 @@
       }
 
       &.stickyFirstCol {
+        td:first-child {
+          background-color: $primary-white;
+        }
+
         th:first-child,
         td:first-child {
           position: sticky;
@@ -68,6 +72,10 @@
       }
 
       &.stickyLastCol {
+        td:last-child {
+          background-color: $primary-white;
+        }
+
         th:last-child,
         td:last-child {
           position: sticky;

--- a/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
+++ b/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
@@ -23,7 +23,7 @@ const TrackListTable = ({ tracks }: TrackListTableProps) => {
       tableHeight={523}
     >
       <TableHeaderUI>
-        <TableCellUI isHeader>번호</TableCellUI>
+        <TableCellUI isHeader colWidth={74}>번호</TableCellUI>
         <TableCellUI isHeader>트랙명 (한글)</TableCellUI>
         <TableCellUI isHeader>트랙명 (영문)</TableCellUI>
       </TableHeaderUI>

--- a/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
+++ b/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
@@ -31,7 +31,7 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
         <TableCellUI isHeader>계정 ID</TableCellUI>
         <TableCellUI isHeader>계정 이메일</TableCellUI>
         <TableCellUI isHeader>기본 요율</TableCellUI>
-        <TableCellUI isHeader>비고</TableCellUI>
+        <TableCellUI isHeader colWidth={280}>비고</TableCellUI>
       </TableHeaderUI>
       <TableBodyUI>
         {accounts.map((account) => {

--- a/src/constants/fallbackPageLayout.ts
+++ b/src/constants/fallbackPageLayout.ts
@@ -1,6 +1,6 @@
 export const NOTFOUND_TYPE_OBJ = {
   image: {
-    src: "/images/error-warning.svg",
+    src: "/images/error-warning.png",
     width: 166,
     height: 170,
     alt: "에러 워닝",
@@ -10,7 +10,7 @@ export const NOTFOUND_TYPE_OBJ = {
 
 export const ERROR_TYPE_OBJ = {
   image: {
-    src: "/images/error-warning.svg",
+    src: "/images/error-warning.png",
     width: 166,
     height: 170,
     alt: "에러 워닝",


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 열이 sticky 할 때 배경색을 줘서, 뒤에 내용물이 보이지 않도록 수정
- 헤더 셀에 colWidth 속성을 넘겨서 각 열의 너비를 지정할 수 있도록 수정 (지정하지 않으면 균등 분배)

### How it Works
<!-- 간단한 로직 설명 -->

열의 너비가 균등 분배 됐을 때 시안에 비해 너무 좁/넓은 열에 대해 colWidth로 명시적으로 열의 너비를 지정합니다.

#### 예시 1) 

- colWidth를 주기 전 마지막 열의 width가 부족해서 버튼이 뚱뚱해짐
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/a048a566-4e06-4133-99ae-c99e2e0b6d03)

- colWidth로 해결
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/84e1ee2a-fe1e-4076-b6e2-d86e9706ebc1)

#### 예시 2)

- 시안
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/8a4678e8-68bf-4b5c-8743-bf9260ee1f92)

- colWIdth를 주기 전 첫 번 째 열이 내용에 비해 너무 넓은 듯함
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/0ff87e60-24db-46cd-b20f-b3bc501f6e78)

- colWidth로 환골탈태
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/fd9c29fe-b86a-46cf-bd68-d66d87fe0424)


### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
테이블 쓰시는 분들 열 너비로 한껏 꾸며주세요~