### PR TITLE
BPS-182/아티스트 현황 페이지 UI 작업

### DIFF
--- a/src/components/artist/ArtistProfileImage/ArtistProfileImage.module.scss
+++ b/src/components/artist/ArtistProfileImage/ArtistProfileImage.module.scss
@@ -1,0 +1,3 @@
+.profileImage {
+  border-radius: 70%;
+}

--- a/src/components/artist/ArtistProfileImage/ArtistProfileImage.tsx
+++ b/src/components/artist/ArtistProfileImage/ArtistProfileImage.tsx
@@ -1,0 +1,34 @@
+import Avatar from "boring-avatars";
+import classNames from "classnames/bind";
+import Image from "next/image";
+
+import { COMBINATION_COLORS, RANDOM_PROFILES } from "@/constants/randomProfileList";
+import getRandomProfileIndex from "@/utils/getRandomProfileIndex";
+
+import styles from "./ArtistProfileImage.module.scss";
+
+interface ArtistProfileImageProps {
+  memberId: number,
+  profileImageUrl: string | null,
+}
+
+const cx = classNames.bind(styles);
+
+const ArtistProfileImage = ({ memberId, profileImageUrl }: ArtistProfileImageProps) => {
+  if (!profileImageUrl) {
+    return (
+      <Avatar
+        size={30}
+        name={RANDOM_PROFILES[getRandomProfileIndex(memberId)]}
+        variant="marble"
+        colors={COMBINATION_COLORS}
+      />
+    );
+  }
+
+  return (
+    <Image className={cx("profileImage")} src={profileImageUrl} width={30} height={30} alt="아티스트 프로필 이미지" />
+  );
+};
+
+export default ArtistProfileImage;

--- a/src/components/artist/ArtistsMainLayout/ArtistsMainLayout.module.scss
+++ b/src/components/artist/ArtistsMainLayout/ArtistsMainLayout.module.scss
@@ -1,0 +1,23 @@
+.container {
+  @include flexbox(column);
+
+  width: 1200px;
+  margin-bottom: 140px;
+  gap: 50px;
+
+  .header {
+    @include flexbox(row, space-between, center);
+
+    .titleWithDropdown {
+      @include flexbox(row, space-between, center);
+
+      gap: 32px;
+    }
+  }
+
+  .title {
+    @include typo(24, bold);
+
+    color: $primary-black;
+  }
+}

--- a/src/components/artist/ArtistsMainLayout/ArtistsMainLayout.tsx
+++ b/src/components/artist/ArtistsMainLayout/ArtistsMainLayout.tsx
@@ -1,0 +1,31 @@
+import classNames from "classnames/bind";
+
+import styles from "./ArtistsMainLayout.module.scss";
+
+interface ArtistsMainLayoutProps {
+  title: string
+  dropdownElement: React.ReactNode
+  searchBarElement: React.ReactNode
+  children: React.ReactNode
+}
+
+const cx = classNames.bind(styles);
+
+const ArtistsMainLayout = ({
+  title, dropdownElement, searchBarElement, children,
+}: ArtistsMainLayoutProps) => {
+  return (
+    <section className={cx("container")}>
+      <div className={cx("header")}>
+        <div className={cx("titleWithDropdown")}>
+          <h1 className={cx("title")}>{title}</h1>
+          {dropdownElement}
+        </div>
+        {searchBarElement}
+      </div>
+      {children}
+    </section>
+  );
+};
+
+export default ArtistsMainLayout;

--- a/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
+++ b/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
@@ -1,0 +1,46 @@
+import Chip from "@/components/common/Chip/Chip";
+import TableBodyUI from "@/components/common/Table/Composition/TableBodyUI";
+import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
+import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
+import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
+import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
+import { MOCK_ARTISTS } from "@/constants/mock";
+
+const ArtistsStatusTable = () => {
+  const artistList = MOCK_ARTISTS.contents;
+
+  return (
+    <TableContainerUI
+      stickyFirstCol
+      tableWidth={1200}
+    >
+      <TableHeaderUI>
+        <TableCellUI isHeader>아티스트명</TableCellUI>
+        <TableCellUI isHeader>매출액</TableCellUI>
+        <TableCellUI isHeader>회사 이익</TableCellUI>
+        <TableCellUI isHeader>정산액</TableCellUI>
+        <TableCellUI isHeader>당월 대표곡</TableCellUI>
+        <TableCellUI isHeader>전월 대비 상승/하락율</TableCellUI>
+      </TableHeaderUI>
+      <TableBodyUI>
+        {artistList.map((artistInfo) => {
+          return (
+            <TableRowUI key={artistInfo.artist.memberId}>
+              <TableCellUI>{artistInfo.artist.koArtistName}</TableCellUI>
+              <TableCellUI>{artistInfo.revenue}</TableCellUI>
+              <TableCellUI>{artistInfo.netIncome}</TableCellUI>
+              <TableCellUI>{artistInfo.settlementAmount}</TableCellUI>
+              <TableCellUI>{artistInfo.representativeTrack}</TableCellUI>
+              <TableCellUI>
+                <Chip percentage={artistInfo.monthlyIncreaseRate} />
+              </TableCellUI>
+            </TableRowUI>
+          );
+        })}
+      </TableBodyUI>
+    </TableContainerUI>
+
+  );
+};
+
+export default ArtistsStatusTable;

--- a/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
+++ b/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
@@ -4,13 +4,19 @@ import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
-import { MOCK_ARTISTS } from "@/constants/mock";
+import { IArtistList } from "@/types/dto";
 
-const ArtistsStatusTable = () => {
-  const artistList = MOCK_ARTISTS.contents;
+interface ArtistsStatusTableProps {
+  artistList: IArtistList[],
+  paginationElement: React.ReactNode
+}
 
+const ArtistsStatusTable = ({
+  artistList, paginationElement,
+}: ArtistsStatusTableProps) => {
   return (
     <TableContainerUI
+      paginationElement={paginationElement}
       stickyFirstCol
       tableWidth={1200}
     >

--- a/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
+++ b/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
@@ -6,6 +6,8 @@ import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import { IArtistList } from "@/types/dto";
 
+import ArtistProfileImage from "../ArtistProfileImage/ArtistProfileImage";
+
 interface ArtistsStatusTableProps {
   artistList: IArtistList[],
   paginationElement: React.ReactNode
@@ -21,6 +23,7 @@ const ArtistsStatusTable = ({
       tableWidth={1200}
     >
       <TableHeaderUI>
+        <TableCellUI isHeader> </TableCellUI>
         <TableCellUI isHeader>아티스트명</TableCellUI>
         <TableCellUI isHeader>매출액</TableCellUI>
         <TableCellUI isHeader>회사 이익</TableCellUI>
@@ -32,6 +35,12 @@ const ArtistsStatusTable = ({
         {artistList.map((artistInfo) => {
           return (
             <TableRowUI key={artistInfo.artist.memberId}>
+              <TableCellUI>
+                <ArtistProfileImage
+                  memberId={artistInfo.artist.memberId}
+                  profileImageUrl={artistInfo.artist.profileImage}
+                />
+              </TableCellUI>
               <TableCellUI>{artistInfo.artist.koArtistName}</TableCellUI>
               <TableCellUI>{artistInfo.revenue}</TableCellUI>
               <TableCellUI>{artistInfo.netIncome}</TableCellUI>

--- a/src/components/layout/GNB/MobileGNB.tsx
+++ b/src/components/layout/GNB/MobileGNB.tsx
@@ -4,8 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { COMBINATION_COLORS, RANDOM_PROFILES } from "@/constants/randomProfileList";
+import getRandomProfileIndex from "@/utils/getRandomProfileIndex";
 
-import getRandomProfileIndex from "./GNB.utils";
 import styles from "./MobileGNB.module.scss";
 import { GNBProps } from "./PCGNB";
 

--- a/src/components/layout/GNB/PCGNB.tsx
+++ b/src/components/layout/GNB/PCGNB.tsx
@@ -4,8 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { COMBINATION_COLORS, RANDOM_PROFILES } from "@/constants/randomProfileList";
+import getRandomProfileIndex from "@/utils/getRandomProfileIndex";
 
-import getRandomProfileIndex from "./GNB.utils";
 import styles from "./PCGNB.module.scss";
 
 interface GNBProps {

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -879,19 +879,6 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       representativeTrack: "love",
       monthlyIncreaseRate: 2.5,
     },
-    {
-      artist: {
-        memberId: 11,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
-        profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
-      },
-      revenue: 300,
-      netIncome: 1234,
-      settlementAmount: 1234124,
-      representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
-    },
   ],
 };
 

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -751,6 +751,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
   contents: [
     {
       artist: {
+        memberId: 1,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -763,6 +764,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 2,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -775,6 +777,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 3,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -787,6 +790,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 4,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -799,6 +803,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 5,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -811,6 +816,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 6,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -823,6 +829,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 7,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -835,6 +842,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 8,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -847,6 +855,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 9,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -859,6 +868,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 10,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
@@ -871,6 +881,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     },
     {
       artist: {
+        memberId: 11,
         koArtistName: "김블루",
         enArtistName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -754,13 +754,13 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
         memberId: 1,
         koArtistName: "김블루",
         enArtistName: "bluekey",
-        profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
+        profileImage: null,
       },
       revenue: 300,
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: -7,
     },
     {
       artist: {
@@ -773,7 +773,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: 0,
     },
     {
       artist: {
@@ -793,26 +793,26 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
         memberId: 4,
         koArtistName: "김블루",
         enArtistName: "bluekey",
-        profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
+        profileImage: null,
       },
       revenue: 300,
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: 0.4,
     },
     {
       artist: {
         memberId: 5,
         koArtistName: "김블루",
         enArtistName: "bluekey",
-        profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
+        profileImage: null,
       },
       revenue: 300,
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: 55.5,
     },
     {
       artist: {
@@ -825,7 +825,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: -200,
     },
     {
       artist: {
@@ -838,20 +838,20 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: 16.8,
     },
     {
       artist: {
         memberId: 8,
         koArtistName: "김블루",
         enArtistName: "bluekey",
-        profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
+        profileImage: null,
       },
       revenue: 300,
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: -2.5,
     },
     {
       artist: {
@@ -864,7 +864,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: null,
     },
     {
       artist: {
@@ -877,7 +877,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
       netIncome: 1234,
       settlementAmount: 1234124,
       representativeTrack: "love",
-      monthlyIncreaseRate: 2.5,
+      monthlyIncreaseRate: 129,
     },
   ],
 };

--- a/src/pages/admin/artists/[month].page.tsx
+++ b/src/pages/admin/artists/[month].page.tsx
@@ -1,4 +1,5 @@
 import ArtistsMainLayout from "@/components/artist/ArtistsMainLayout/ArtistsMainLayout";
+import ArtistsStatusTable from "@/components/artist/ArtistsStatusTable/ArtistsStatusTable";
 import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
 
@@ -8,12 +9,15 @@ const ArtistsStatusPage = () => {
       title="아티스트 현황"
       dropdownElement={
         <MonthPickerDropdown />
-    }
-      searchBarElement={<SearchBar placeholder="검색어를 입력해주세요." onClick={() => { console.log("검색!"); }} />}
+      }
+      searchBarElement={(
+        <SearchBar
+          placeholder="검색어를 입력해주세요."
+          onClick={() => { console.log("검색!"); }}
+        />
+      )}
     >
-      <div>
-        아티스트 현황 테이블
-      </div>
+      <ArtistsStatusTable />
     </ArtistsMainLayout>
   );
 };

--- a/src/pages/admin/artists/[month].page.tsx
+++ b/src/pages/admin/artists/[month].page.tsx
@@ -5,10 +5,12 @@ import Pagination from "@/components/common/Pagination/Pagination";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
 import { MOCK_ARTISTS } from "@/constants/mock";
 import { ITEMS_PER_ARTISTS_TABLE } from "@/constants/pagination";
+import useToast from "@/hooks/useToast";
 
 const ArtistsStatusPage = () => {
   // TODO: url의 pageParam을 받아 api fetch
   const mockArtists = MOCK_ARTISTS;
+  const { showToast } = useToast();
 
   return (
     <ArtistsMainLayout
@@ -19,7 +21,7 @@ const ArtistsStatusPage = () => {
       searchBarElement={(
         <SearchBar
           placeholder="검색어를 입력해주세요."
-          onClick={() => { console.log("검색!"); }}
+          onClick={() => { showToast("검색"); }}
         />
       )}
     >

--- a/src/pages/admin/artists/[month].page.tsx
+++ b/src/pages/admin/artists/[month].page.tsx
@@ -1,0 +1,21 @@
+import ArtistsMainLayout from "@/components/artist/ArtistsMainLayout/ArtistsMainLayout";
+import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
+import SearchBar from "@/components/common/SearchBar/SearchBar";
+
+const ArtistsStatusPage = () => {
+  return (
+    <ArtistsMainLayout
+      title="아티스트 현황"
+      dropdownElement={
+        <MonthPickerDropdown />
+    }
+      searchBarElement={<SearchBar placeholder="검색어를 입력해주세요." onClick={() => { console.log("검색!"); }} />}
+    >
+      <div>
+        아티스트 현황 테이블
+      </div>
+    </ArtistsMainLayout>
+  );
+};
+
+export default ArtistsStatusPage;

--- a/src/pages/admin/artists/[month].page.tsx
+++ b/src/pages/admin/artists/[month].page.tsx
@@ -1,9 +1,15 @@
 import ArtistsMainLayout from "@/components/artist/ArtistsMainLayout/ArtistsMainLayout";
 import ArtistsStatusTable from "@/components/artist/ArtistsStatusTable/ArtistsStatusTable";
 import MonthPickerDropdown from "@/components/common/MonthPicker/MonthPickerDropdown";
+import Pagination from "@/components/common/Pagination/Pagination";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
+import { MOCK_ARTISTS } from "@/constants/mock";
+import { ITEMS_PER_ARTISTS_TABLE } from "@/constants/pagination";
 
 const ArtistsStatusPage = () => {
+  // TODO: url의 pageParam을 받아 api fetch
+  const mockArtists = MOCK_ARTISTS;
+
   return (
     <ArtistsMainLayout
       title="아티스트 현황"
@@ -17,7 +23,16 @@ const ArtistsStatusPage = () => {
         />
       )}
     >
-      <ArtistsStatusTable />
+      <ArtistsStatusTable
+        artistList={mockArtists.contents}
+        paginationElement={(
+          <Pagination
+            activePage={1}
+            totalItems={mockArtists.totalItems}
+            itemsPerPage={ITEMS_PER_ARTISTS_TABLE}
+          />
+        )}
+      />
     </ArtistsMainLayout>
   );
 };

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -134,6 +134,7 @@ export interface IAlbumDashboardCard {
 // /api/v1/artist
 export interface IArtistList {
   artist: {
+    memberId: number,
     koArtistName: string,
     enArtistName: string,
     profileImage: string

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -137,7 +137,7 @@ export interface IArtistList {
     memberId: number,
     koArtistName: string,
     enArtistName: string,
-    profileImage: string
+    profileImage: string | null
   },
   revenue: number | null,
   netIncome: number | null,

--- a/src/utils/getRandomProfileIndex.ts
+++ b/src/utils/getRandomProfileIndex.ts
@@ -10,10 +10,12 @@ const calculateAsciiSum = (loginId: string) => {
   return totalSum;
 };
 
-const getRandomProfileIndex = (loginId: string) => {
-  const totlaAsciiSum = calculateAsciiSum(loginId);
-
-  return totlaAsciiSum % RANDOM_PROFILES_LENGTH;
+const getRandomProfileIndex = (userId: string | number) => {
+  if (typeof userId === "string") {
+    const totlaAsciiSum = calculateAsciiSum(userId);
+    return totlaAsciiSum % RANDOM_PROFILES_LENGTH;
+  }
+  return userId % RANDOM_PROFILES_LENGTH;
 };
 
 export default getRandomProfileIndex;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
- 아티스트 현황 페이지의 UI 작업
- mock 데이터에서 아티스트 id(`memberId`) 추가
- chip은 이전 PR에서 수정한 부분이 있어서 현재 UI랑 조금 달라졌습니당

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/2109cb53-65bc-4cad-a807-adb5f76ada6d)


### To Reviewers
### 아티스트명 클릭 가능함을 UI로 보이는게 좋을 것 같은데 아티스트명엔 pointer & 밑줄을 추가할까요?
