### PR TITLE
BPS-176/비밀번호 재설정 폼 추가

### DIFF
--- a/src/components/auth/ChangePasswordForm/ChangePasswordForm.module.scss
+++ b/src/components/auth/ChangePasswordForm/ChangePasswordForm.module.scss
@@ -1,0 +1,14 @@
+.container {
+  width: 100%;
+
+  @include flexbox(column, false, false);
+
+  gap: 32px;
+
+  .title {
+    @include typo(20, bold);
+
+    color: $primary-black;
+    line-height: 150%;
+  }
+}

--- a/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
@@ -7,7 +7,19 @@ import CurrentPasswordForm from "./CurrentPasswordForm/CurrentPasswordForm";
 import NewPasswordForm from "./NewPasswordForm/NewPasswordForm";
 
 const cx = classNames.bind(styles);
-
+/**
+ * 비밀번호 변경 폼
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param {Fucntion} onComplete 비밀번호 변경 모든 단계를 완료한 뒤 실행할 함수
+ * @example
+ * ```tsx
+ * const [showModal, setShowModal] = useState(false);
+ * ...
+ * <Modal isOpen={showModal}>
+ *   <ChangePasswordForm onComplete={()=>{alert("비밀번호 변경 완료!"); setShowModal(false)}} />
+ * </Modal>
+ * ```
+ */
 const ChangePasswordForm = ({ onComplete }: { onComplete: () => void }) => {
   const [currentPage, setCurrentPage] = useState(1);
 

--- a/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
@@ -18,7 +18,11 @@ const ChangePasswordForm = ({ onComplete }: { onComplete: () => void }) => {
         <CurrentPasswordForm
           onSuccess={() => { setCurrentPage((prev) => { return prev + 1; }); }}
         />
-      ) : <NewPasswordForm onSuccess={onComplete} />}
+      ) : (
+        <NewPasswordForm
+          onSuccess={() => { onComplete(); setTimeout(() => { setCurrentPage(1); }, 500); }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+import classNames from "classnames/bind";
+
+import styles from "./ChangePasswordForm.module.scss";
+import CurrentPasswordForm from "./CurrentPasswordForm/CurrentPasswordForm";
+import NewPasswordForm from "./NewPasswordForm/NewPasswordForm";
+
+const cx = classNames.bind(styles);
+
+const ChangePasswordForm = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  return (
+    <div className={cx("container")}>
+      <h1 className={cx("title")}>비밀번호 재설정</h1>
+      {currentPage === 1 ? (
+        <CurrentPasswordForm
+          onSuccess={() => { setCurrentPage((prev) => { return prev + 1; }); }}
+        />
+      ) : <NewPasswordForm />}
+    </div>
+  );
+};
+
+export default ChangePasswordForm;

--- a/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/ChangePasswordForm.tsx
@@ -8,8 +8,9 @@ import NewPasswordForm from "./NewPasswordForm/NewPasswordForm";
 
 const cx = classNames.bind(styles);
 
-const ChangePasswordForm = () => {
+const ChangePasswordForm = ({ onComplete }: { onComplete: () => void }) => {
   const [currentPage, setCurrentPage] = useState(1);
+
   return (
     <div className={cx("container")}>
       <h1 className={cx("title")}>비밀번호 재설정</h1>
@@ -17,7 +18,7 @@ const ChangePasswordForm = () => {
         <CurrentPasswordForm
           onSuccess={() => { setCurrentPage((prev) => { return prev + 1; }); }}
         />
-      ) : <NewPasswordForm />}
+      ) : <NewPasswordForm onSuccess={onComplete} />}
     </div>
   );
 };

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.module.scss
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.module.scss
@@ -1,0 +1,11 @@
+.container {
+  @include flexbox(column, false, center);
+
+  // TextField가 width에 꽉 차도록 스타일링
+  & > div {
+    width: 100%;
+  }
+
+  width: 455px;
+  gap: 176px;
+}

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.module.scss
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.module.scss
@@ -8,4 +8,14 @@
 
   width: 455px;
   gap: 176px;
+
+  .inputGroupContainer {
+    @include flexbox(column);
+
+    gap: 16px;
+  }
+
+  &.newPasswordForm {
+    gap: 72px;
+  }
 }

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -27,7 +27,7 @@ const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
     message: "입력하신 비밀번호와 현재 비밀번호가 일치하지 않습니다.",
   });
   const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = (data) => {
-    // TODO: /api/v1/auth/member/password/confirm 에 POST효청
+    // TODO: /api/v1/auth/member/password/confirm 에 POST요청해서 response에 따라 성공, 에러 처리
     if (data.password === "1234qwer") {
       onSuccess();
     } else {

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -1,0 +1,52 @@
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import classNames from "classnames/bind";
+
+import Button from "@/components/common/CommonBtns/Button/Button";
+import PasswordField from "@/components/common/Inputs/PasswordInput/PasswordField";
+import useAlertModal from "@/hooks/useAlertModal";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+
+import styles from "./CurrentPasswordForm.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface IChangePasswordFieldValues {
+  password: string;
+}
+
+interface CurrentPasswordFormProps {
+  onSuccess: () => void;
+}
+
+const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
+  const { register, formState: { errors }, handleSubmit } = useForm<IChangePasswordFieldValues>();
+  const { showAlertModal } = useAlertModal({
+    type: MODAL_TYPE.ERROR,
+    title: "비밀번호 오류",
+    message: "입력하신 비밀번호와 현재 비밀번호가 일치하지 않습니다.",
+  });
+  const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = (data) => {
+    // TODO: /api/v1/auth/member/password/confirm 에 POST효청
+    if (data.password === "1234qwer") {
+      onSuccess();
+    } else {
+      showAlertModal();
+    }
+  };
+  return (
+    <div className={cx("container")}>
+      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+      <form onSubmit={handleSubmit(handleClickNext)} className={cx("container")}>
+        <PasswordField
+          label="현재 비밀번호 입력"
+          {...register("password")}
+          errors={errors}
+        />
+        <Button theme="dark" size="medium" type="submit">다음</Button>
+      </form>
+    </div>
+  );
+};
+
+export default CurrentPasswordForm;

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -35,7 +35,7 @@ const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
     }
   };
   return (
-    <div className={cx("container")}>
+    <>
       {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
       <form onSubmit={handleSubmit(handleClickNext)} className={cx("container")}>
         <PasswordField
@@ -45,7 +45,7 @@ const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
         />
         <Button theme="dark" size="medium" type="submit">다음</Button>
       </form>
-    </div>
+    </>
   );
 };
 

--- a/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
@@ -1,35 +1,77 @@
-// import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 
 import classNames from "classnames/bind";
 
 import Button from "@/components/common/CommonBtns/Button/Button";
 import PasswordField from "@/components/common/Inputs/PasswordInput/PasswordField";
+import useAlertModal from "@/hooks/useAlertModal";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
 import styles from "../CurrentPasswordForm/CurrentPasswordForm.module.scss";
 
 const cx = classNames.bind(styles);
 
-// interface INewPasswordFieldValues {
-//   password: string;
-//   confirmPassword: string;
-// }
+interface INewPasswordFieldValues {
+  password: string;
+  confirmPassword: string;
+}
 
-const NewPasswordForm = () => {
-  // const { register } = useForm<INewPasswordFieldValues>();
+const NewPasswordForm = ({ onSuccess }: { onSuccess: () => void }) => {
+  const {
+    register, formState: { errors }, handleSubmit, getValues,
+  } = useForm<INewPasswordFieldValues>({ mode: "onBlur" });
+  const { showAlertModal } = useAlertModal({
+    type: MODAL_TYPE.ERROR,
+    title: "에러 발생",
+    message: `알 수 없는 에러가 발생하였습니다. 
+    잠시 후에 다시 시도해주세요.`,
+  });
+  const handleClickDone: SubmitHandler<INewPasswordFieldValues> = (data) => {
+    // TODO: /api/v1/auth/member/password 로 patch요청 try-catch
+    if (data.password === "1234qwer") {
+      onSuccess();
+    } else {
+      showAlertModal();
+    }
+  };
   return (
-    <div className={cx("container", "newPasswordForm")}>
-      <div className={cx("inputGroupContainer")}>
-        <PasswordField
-          label="새 비밀번호 입력"
-          errors={{}}
-        />
-        <PasswordField
-          label="비밀번호 확인"
-          errors={{}}
-        />
-      </div>
-      <Button size="medium" theme="dark" type="submit">변경 완료</Button>
-    </div>
+    <>
+      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+      <form className={cx("container", "newPasswordForm")} onSubmit={handleSubmit(handleClickDone)}>
+        <div className={cx("inputGroupContainer")}>
+          <PasswordField
+            label="새 비밀번호 입력aaa"
+            {...register("password", {
+              required: "*비밀번호를 입력하세요.",
+              minLength: {
+                value: 8,
+                message: "*비밀번호는 8자 이상으로 입력해주세요.",
+              },
+              maxLength: {
+                value: 16,
+                message: "*비밀번호는 16자 이하로 입력해주세요.",
+              },
+              pattern: {
+                value: /^[a-zA-Z0-9!@#$%^&*()-_+=<>?]*$/,
+                message: "*영문, 숫자, 특수문자(!@#$%^&*()-_+=<>?)만 사용해주세요.",
+              },
+            })}
+            errors={errors}
+          />
+          <PasswordField
+            label="비밀번호 확인"
+            {...register("confirmPassword", {
+              required: "*비밀번호를 확인해주세요.",
+              validate: {
+                matchesPassword: (v: string) => { return v === getValues("password") || "*비밀번호가 일치하지 않습니다."; },
+              },
+            })}
+            errors={errors}
+          />
+        </div>
+        <Button size="medium" theme="dark" type="submit">변경 완료</Button>
+      </form>
+    </>
   );
 };
 

--- a/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
@@ -1,0 +1,36 @@
+// import { useForm } from "react-hook-form";
+
+import classNames from "classnames/bind";
+
+import Button from "@/components/common/CommonBtns/Button/Button";
+import PasswordField from "@/components/common/Inputs/PasswordInput/PasswordField";
+
+import styles from "../CurrentPasswordForm/CurrentPasswordForm.module.scss";
+
+const cx = classNames.bind(styles);
+
+// interface INewPasswordFieldValues {
+//   password: string;
+//   confirmPassword: string;
+// }
+
+const NewPasswordForm = () => {
+  // const { register } = useForm<INewPasswordFieldValues>();
+  return (
+    <div className={cx("container", "newPasswordForm")}>
+      <div className={cx("inputGroupContainer")}>
+        <PasswordField
+          label="새 비밀번호 입력"
+          errors={{}}
+        />
+        <PasswordField
+          label="비밀번호 확인"
+          errors={{}}
+        />
+      </div>
+      <Button size="medium" theme="dark" type="submit">변경 완료</Button>
+    </div>
+  );
+};
+
+export default NewPasswordForm;

--- a/src/components/my-profile/AdminProfileForm/AdminProfileForm.tsx
+++ b/src/components/my-profile/AdminProfileForm/AdminProfileForm.tsx
@@ -1,10 +1,16 @@
+import { useState } from "react";
 import { SubmitHandler, useFormContext } from "react-hook-form";
 
 import classNames from "classnames/bind";
 
+import ChangePasswordForm from "@/components/auth/ChangePasswordForm/ChangePasswordForm";
+import Button from "@/components/common/CommonBtns/Button/Button";
 import TextField from "@/components/common/Inputs/TextField/TextField";
 import Spacing from "@/components/common/Layouts/Spacing";
+import Modal from "@/components/common/Modals/Modal";
+import useToast from "@/hooks/useToast";
 import { IAdminUpdateProfileFieldValues } from "@/types/dto";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
 import styles from "./AdminProfileForm.module.scss";
 
@@ -16,6 +22,17 @@ interface AdminProfileFormProps {
 
 const AdminProfileForm = ({ onSubmit }: AdminProfileFormProps) => {
   const { register, handleSubmit } = useFormContext();
+  const { showToast } = useToast();
+  const [isChangePasswordFormOpen, setIsChangePasswordFormOpen] = useState(false);
+
+  const closeModal = () => {
+    setIsChangePasswordFormOpen(false);
+  };
+
+  const showModal = () => {
+    setIsChangePasswordFormOpen(true);
+  };
+
   return (
     <div className={cx("container")}>
       {/*  eslint-disable-next-line @typescript-eslint/no-misused-promises */}
@@ -38,6 +55,11 @@ const AdminProfileForm = ({ onSubmit }: AdminProfileFormProps) => {
         />
         <Spacing size={0} />
       </form>
+      <Spacing size={6} />
+      <Button size="medium" theme="dark" onClick={showModal}>비밀번호 재설정하기</Button>
+      <Modal type={MODAL_TYPE.FORM} onClose={closeModal} open={isChangePasswordFormOpen}>
+        <ChangePasswordForm onComplete={() => { closeModal(); showToast("비밀번호가 재설정 되었습니다"); }} />
+      </Modal>
     </div>
   );
 };

--- a/src/components/my-profile/ArtistProfileForm/ArtistProfileForm.tsx
+++ b/src/components/my-profile/ArtistProfileForm/ArtistProfileForm.tsx
@@ -1,9 +1,16 @@
+import { useState } from "react";
 import { SubmitHandler, useFormContext } from "react-hook-form";
 
 import classNames from "classnames/bind";
 
+import ChangePasswordForm from "@/components/auth/ChangePasswordForm/ChangePasswordForm";
+import Button from "@/components/common/CommonBtns/Button/Button";
 import TextField from "@/components/common/Inputs/TextField/TextField";
+import Spacing from "@/components/common/Layouts/Spacing";
+import Modal from "@/components/common/Modals/Modal";
+import useToast from "@/hooks/useToast";
 import { IArtistUpdateProfileFieldValues } from "@/types/dto";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
 import styles from "./ArtistProfileForm.module.scss";
 
@@ -15,6 +22,16 @@ interface ArtistProfileFormProps {
 
 const ArtistProfileForm = ({ onSubmit }: ArtistProfileFormProps) => {
   const { register, handleSubmit } = useFormContext();
+  const { showToast } = useToast();
+  const [isChangePasswordFormOpen, setIsChangePasswordFormOpen] = useState(false);
+
+  const closeModal = () => {
+    setIsChangePasswordFormOpen(false);
+  };
+
+  const showModal = () => {
+    setIsChangePasswordFormOpen(true);
+  };
   return (
     <div className={cx("container")}>
       {/*  eslint-disable-next-line @typescript-eslint/no-misused-promises */}
@@ -42,6 +59,11 @@ const ArtistProfileForm = ({ onSubmit }: ArtistProfileFormProps) => {
           onSave={() => {}}
         />
       </form>
+      <Spacing size={6} />
+      <Button size="medium" theme="dark" onClick={showModal}>비밀번호 재설정하기</Button>
+      <Modal type={MODAL_TYPE.FORM} onClose={closeModal} open={isChangePasswordFormOpen}>
+        <ChangePasswordForm onComplete={() => { closeModal(); showToast("비밀번호가 재설정 되었습니다"); }} />
+      </Modal>
     </div>
   );
 };

--- a/src/pages/kenny.page.tsx
+++ b/src/pages/kenny.page.tsx
@@ -18,11 +18,13 @@ import useAlertModal, { IUseAlertModalParam } from "@/hooks/useAlertModal";
 import Button from "@/components/common/CommonBtns/Button/Button";
 import Spacing from "@/components/common/Layouts/Spacing";
 import ImageUploader from "@/components/common/ImageUploader/ImageUploader";
+import ChangePasswordForm from "@/components/auth/ChangePasswordForm/ChangePasswordForm";
 
 const KennyPage = () => {
   const { showToast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [isChangePassModalOpen, setIsChangePasswordOpen] = useState(false);
   const {
     register,
     formState: { errors, defaultValues },
@@ -212,6 +214,14 @@ const KennyPage = () => {
       <Button size="large" theme="bright" onClick={()=>{showAlertModal()}}>useAlert모달로 열기</Button>
       <Spacing size={100} />
       <ImageUploader shape="circle" {...register("profileImg")} type="file"/>
+      <br />
+      <br />
+      <br />
+      <br />
+      <Button size="large" theme="dark" onClick={()=>{setIsChangePasswordOpen(true)}}>비밀번호 변경</Button>
+      <Modal type={MODAL_TYPE.FORM} open={isChangePassModalOpen} onClose={()=>{setIsChangePasswordOpen(false)}}>
+        <ChangePasswordForm />
+      </Modal>
     </div>
   );
 };

--- a/src/pages/kenny.page.tsx
+++ b/src/pages/kenny.page.tsx
@@ -220,7 +220,7 @@ const KennyPage = () => {
       <br />
       <Button size="large" theme="dark" onClick={()=>{setIsChangePasswordOpen(true)}}>비밀번호 변경</Button>
       <Modal type={MODAL_TYPE.FORM} open={isChangePassModalOpen} onClose={()=>{setIsChangePasswordOpen(false)}}>
-        <ChangePasswordForm />
+        <ChangePasswordForm onComplete={()=>{setIsChangePasswordOpen(false); showToast("비밀번호가 변경되었습니다.")}}/>
       </Modal>
     </div>
   );


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 내 프로필 페이지의 비밀번호 재설정 폼을 포함한 모달을 띄우는 버튼을 추가했습니다. 
- 비밀번호 재설정 폼 컴포넌트를 추가했습니다.

### How it Works
<!-- 간단한 로직 설명 -->
- 재설정 폼은 1, 2 페이지로 나뉘게 되며, 각각의 페이지마다 서로 다른 폼을 렌더링 하게 됩니다.
- ChangePasswordForm은 currentPage라는 로컬 상태를 가지며, 이 상태가 1인 경우 현재 비밀번호를 입력하는 폼을 렌더링 하고,
2인 경우 새 비밀번호를 입력하는 폼을 렌더링 합니다. 
- 내 프로필 페이지에서 비밀번호 재설정 버튼을 누르면 form타입 모달이 띄워지고, 해당 모달 안에 ChangePasswordForm을 렌더링 합니다. 

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
