### PR TITLE
BPS-191/페이지 스크롤바 스타일링 & 그에 따른 모달 수정

### DIFF
--- a/src/components/common/Modals/Modal.module.scss
+++ b/src/components/common/Modals/Modal.module.scss
@@ -9,7 +9,7 @@ $form-type-padding: 32px;
 $albuminfo-type-padding: 32px 32px 50px;
 
 .dialog {
-  max-width: calc(100vw + 20px);
+  max-width: calc(100dvw + 20px);
   max-height: 100vh;
   margin: auto;
   overflow: hidden;
@@ -22,7 +22,7 @@ $albuminfo-type-padding: 32px 32px 50px;
   .overlay {
     @include flexbox(row, center, center);
 
-    width: calc(100vw + 20px);
+    width: calc(100dvw + 20px);
     height: 100vh;
     overflow: hidden;
     background-color: rgb(0 0 0 / 66%);

--- a/src/components/common/Modals/Modal.module.scss
+++ b/src/components/common/Modals/Modal.module.scss
@@ -15,13 +15,44 @@ $albuminfo-type-padding: 32px 32px 50px;
   overflow: hidden;
   background-color: transparent;
 
-  &::-webkit-scrollbar-track {
-    border-radius: 20px;
-    background-color: $primary-white;
-  }
-
   &::backdrop {
     background-color: transparent;
+  }
+
+  .overlay {
+    @include flexbox(row, center, center);
+
+    width: calc(100vw + 20px);
+    height: 100vh;
+    overflow: hidden;
+    background-color: rgb(0 0 0 / 66%);
+  }
+
+  .container {
+    @include scrollbar(15);
+
+    &::-webkit-scrollbar-track {
+      border-radius: 20px;
+      background-color: $primary-white;
+    }
+
+    max-width: 90%;
+    margin-right: 10px;
+    overflow: auto;
+    border-radius: 8px;
+    background-color: $primary-white;
+    /* stylelint-disable-next-line scss/dollar-variable-colon-space-after */
+    $modal-type-padding-map:
+      "error" $error-type-padding,
+      "confirm" $confirm-type-padding,
+      "form" $form-type-padding,
+      "albumInfo" $albuminfo-type-padding;
+
+    @each $type, $padding in $modal-type-padding-map {
+      &.#{$type} {
+        padding: $padding;
+      }
+    }
   }
 
   &[open] {
@@ -41,37 +72,6 @@ $albuminfo-type-padding: 32px 32px 50px;
       .overlay {
         animation: $fade-out;
       }
-    }
-  }
-}
-
-.overlay {
-  @include flexbox(row, center, center);
-
-  width: calc(100vw + 20px);
-  height: 100vh;
-  overflow: hidden;
-  background-color: rgb(0 0 0 / 66%);
-}
-
-.container {
-  @include scrollbar(15);
-
-  max-width: 90%;
-  margin-right: 10px;
-  overflow: auto;
-  border-radius: 8px;
-  background-color: $primary-white;
-  /* stylelint-disable-next-line scss/dollar-variable-colon-space-after */
-  $modal-type-padding-map:
-    "error" $error-type-padding,
-    "confirm" $confirm-type-padding,
-    "form" $form-type-padding,
-    "albumInfo" $albuminfo-type-padding;
-
-  @each $type, $padding in $modal-type-padding-map {
-    &.#{$type} {
-      padding: $padding;
     }
   }
 }

--- a/src/components/common/Modals/Modal.module.scss
+++ b/src/components/common/Modals/Modal.module.scss
@@ -9,10 +9,11 @@ $form-type-padding: 32px;
 $albuminfo-type-padding: 32px 32px 50px;
 
 .dialog {
+  max-width: calc(100vw + 20px);
+  max-height: 100vh;
   margin: auto;
+  overflow: hidden;
   background-color: transparent;
-
-  @include scrollbar(15);
 
   &::-webkit-scrollbar-track {
     border-radius: 20px;
@@ -20,28 +21,45 @@ $albuminfo-type-padding: 32px 32px 50px;
   }
 
   &::backdrop {
-    background-color: rgb(0 0 0 / 66%);
+    background-color: transparent;
   }
 
   &[open] {
-    animation: $fade-in, $float-up;
+    .container {
+      animation: $fade-in, $float-up;
+    }
 
-    &::backdrop {
+    .overlay {
       animation: $fade-in;
     }
 
     &.closing {
-      animation: $fade-out, $float-down;
+      .container {
+        animation: $fade-out, $float-down;
+      }
 
-      &::backdrop {
+      .overlay {
         animation: $fade-out;
       }
     }
   }
 }
 
+.overlay {
+  @include flexbox(row, center, center);
+
+  width: calc(100vw + 20px);
+  height: 100vh;
+  overflow: hidden;
+  background-color: rgb(0 0 0 / 66%);
+}
+
 .container {
-  width: fit-content;
+  @include scrollbar(15);
+
+  max-width: 90%;
+  margin-right: 10px;
+  overflow: auto;
   border-radius: 8px;
   background-color: $primary-white;
   /* stylelint-disable-next-line scss/dollar-variable-colon-space-after */

--- a/src/components/common/Modals/Modal.tsx
+++ b/src/components/common/Modals/Modal.tsx
@@ -50,13 +50,14 @@ const Modal = ({
   type, open, onClose, children, ...props
 }: ModalProps) => {
   const modalRef = useRef<HTMLDialogElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   const handleAnimationEnd = () => {
     if (!open) modalRef.current?.close();
   };
 
   const handleClick: MouseEventHandler<HTMLDialogElement> = ({ target }) => {
-    if (target === modalRef.current) onClose();
+    if (target === modalRef.current || target === overlayRef.current) onClose();
   };
 
   useEffect(() => {
@@ -65,7 +66,7 @@ const Modal = ({
       document.body.style.overflow = "hidden";
     }
     return () => {
-      document.body.style.overflow = "scroll";
+      document.body.style.overflow = "auto";
     };
   }, [open]);
 
@@ -81,8 +82,10 @@ const Modal = ({
       onAnimationEnd={handleAnimationEnd}
       {...props}
     >
-      <div className={cx("container", [MODAL_TYPE_CLASSNAME_MAP[type]])}>
-        {children}
+      <div className={cx("overlay")} ref={overlayRef}>
+        <div className={cx("container", [MODAL_TYPE_CLASSNAME_MAP[type]])}>
+          {children}
+        </div>
       </div>
     </dialog>
   );

--- a/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.module.scss
+++ b/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.module.scss
@@ -10,17 +10,18 @@
   }
 
   .contentContainer {
-    @include flexbox(row);
-
-    gap: 96px;
+    width: 1255px;
     height: 523px;
     padding-left: 46px;
 
     .albumInfoContainer {
-      @include flexbox(column, flex-start, center);
-
-      gap: 32px;
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      margin-right: 96px;
       color: $primary-black;
+      vertical-align: top;
+      gap: 32px;
 
       .imageWrapper {
         @include flexbox(row, center, center);
@@ -64,6 +65,7 @@
     }
 
     .tableWrapper {
+      display: inline-block;
       width: 730px;
     }
   }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -26,6 +26,25 @@ body {
   font-size: 16px;
   line-height: 1;
   word-break: keep-all;
+
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+
+  &::-webkit-scrollbar {
+    width: 20px;
+    height: 20px;
+  }
+
+  &::-webkit-scrollbar-track {
+    width: 0;
+    background-color: #dbddde;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: #b6becc;
+  }
 }
 
 input,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 페이지(body 태그)에 스크롤바 스타일링
- 스크롤바 영역으로 모달이 사라질 때 위치가 변하는 이슈 해결 (모달에 .overlay div 추가)

- 이슈 해결간 생긴 사이드 이펙트 이슈 해결

#### 해결 전
![DemoCreatorRec_2023-08-24-10-41-29](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/a5ad6f56-f909-4229-b648-7dfd8667a762)

#### 해결 후
![DemoCreatorRec_2023-08-24-10-51-52](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/95669838-cc26-413e-9bee-00388ae7234a)
![DemoCreatorRec_2023-08-24-10-55-16](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/e3297e3c-9b0a-49e1-b1e3-52373d95c908)


### How it Works
<!-- 간단한 로직 설명 -->

#### 문제 상황
페이지와 스크롤바가 overlay 되는 맥과 달리, 윈도우는 페이지와 스크롤바가 서로 분리되어 생김 ([관련 문서](https://idchoi2.medium.com/os%EB%B3%84-scrollbar-%EB%8F%99%EC%9E%91%EA%B3%BC-scrollbar-%EC%8A%A4%ED%83%80%EC%9D%BC%ED%95%98%EA%B8%B0-%ED%98%B9%EC%9D%80-%EC%97%86%EC%95%A0%EA%B8%B0-434edfa1a246#:~:text=%EC%9C%88%EB%8F%84%EC%9A%B0%EC%9D%98%20%EA%B2%BD%EC%9A%B0%20%EC%8A%A4%ED%81%AC%EB%A1%A4%EB%B0%94%EA%B0%80%20%EC%BB%A8%ED%85%90%EC%B8%A0%20%EC%98%81%EC%97%AD%20%EB%B0%96%EC%97%90%20%EB%94%B0%EB%A1%9C%20%EC%A1%B4%EC%9E%AC%ED%95%98%EB%8A%94%EA%B2%83%20%EC%B2%98%EB%9F%BC%20%EB%B3%B4%EC%9D%B4%EA%B8%B0%20%EB%95%8C%EB%AC%B8%EC%97%90%20%EC%8B%A4%EC%A0%9C%EB%A1%9C%EB%8A%94%20%EC%BB%A8%ED%85%90%EC%B8%A0%20%EC%98%81%EC%97%AD%EC%97%90%EC%84%9C%20%EC%8A%A4%ED%81%AC%EB%A1%A4%EB%B0%94%EC%9D%98%20%ED%81%AC%EA%B8%B0%EB%A7%8C%ED%81%BC%20%EC%A4%84%EC%96%B4%EB%93%A0%EA%B2%83%EC%B2%98%EB%9F%BC%20%EB%B3%B4%EC%9D%B8%EB%8B%A4.))
모달이 열리고 닫힐 때 overflow가 hidden, auto로 바뀌는데 이 때 생기는 스크롤바의 width로 모달의 중간 위치가 바뀌면서 순간적으로 모달이 이동함

#### 해결 방법
모달의 기본 특성인 ::backdrop을 사용하지 않고, .container를 감싸는 .overlay 태그를 추가로 생성
이 때 .overlay의 width를 (100vh + 20px(=스크롤바 width))로 설정
모달의 중간 위치를 보정하기 위해 .content에 margin-right: 10px(=스크롤바 width/2) 설정
그 밖에 .overlay 태그를 추가하며 생긴, outsideClick 안되는 문제, 모달이 화면에 꽉찰 때 overflow 되지 않는 문제 등 해결

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
