### PR TITLE
BPS-193/모달용 Tooltip 컴포넌트 제작

### DIFF
--- a/src/components/common/Tooltip/ModalTooltip.tsx
+++ b/src/components/common/Tooltip/ModalTooltip.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames/bind";
 
 import Tooltip from "./Tooltip";
 import styles from "./Tooltip.module.scss";
+import { PosType, checkTextOverflow, getPosition } from "./Tooltip.utils";
 
 interface ModalTooltipProps {
   message: string,
@@ -15,10 +16,15 @@ const cx = classNames.bind(styles);
 const ModalTooltipRoot = ({ message, children }: ModalTooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
+  const pos = useRef<PosType | null>(null);
 
   const handleMouseOver = (e: MouseEvent<HTMLDivElement>) => {
-    console.log(e.currentTarget?.children[0]);
-    setIsVisible(true);
+    const visible = checkTextOverflow(e.currentTarget.children[0]);
+
+    if (visible) {
+      pos.current = getPosition(tooltipRef);
+      setIsVisible(true);
+    }
   };
 
   const handleMouseLeave = () => {
@@ -35,7 +41,7 @@ const ModalTooltipRoot = ({ message, children }: ModalTooltipProps) => {
     >
       {children}
       {isVisible
-      && <Tooltip message={message} style={{ x: 100, y: 100 }} />}
+      && <Tooltip message={message} style={pos.current?.style} />}
     </div>
   );
 };

--- a/src/components/common/Tooltip/ModalTooltip.tsx
+++ b/src/components/common/Tooltip/ModalTooltip.tsx
@@ -1,0 +1,43 @@
+import { MouseEvent, useRef, useState } from "react";
+
+import classNames from "classnames/bind";
+
+import Tooltip from "./Tooltip";
+import styles from "./Tooltip.module.scss";
+
+interface ModalTooltipProps {
+  message: string,
+  children: React.ReactNode
+}
+
+const cx = classNames.bind(styles);
+
+const ModalTooltipRoot = ({ message, children }: ModalTooltipProps) => {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  const handleMouseOver = (e: MouseEvent<HTMLDivElement>) => {
+    console.log(e.currentTarget?.children[0]);
+    setIsVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsVisible(false);
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+    <div
+      className={cx("tooltipRoot")}
+      ref={tooltipRef}
+      onMouseOver={handleMouseOver}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {isVisible
+      && <Tooltip message={message} style={{ x: 100, y: 100 }} />}
+    </div>
+  );
+};
+
+export default ModalTooltipRoot;

--- a/src/components/common/Tooltip/Tooltip.module.scss
+++ b/src/components/common/Tooltip/Tooltip.module.scss
@@ -8,6 +8,7 @@
   @include typo(14);
 
   width: fit-content;
+  min-width: 117px;
   max-width: 220px;
   padding: 12px 15px;
   border-radius: 6px;
@@ -30,5 +31,3 @@
     border-color: $primary-black transparent;
   }
 }
-
-/* ModalTooltip styles */

--- a/src/components/common/Tooltip/Tooltip.module.scss
+++ b/src/components/common/Tooltip/Tooltip.module.scss
@@ -30,3 +30,5 @@
     border-color: $primary-black transparent;
   }
 }
+
+/* ModalTooltip styles */

--- a/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
+++ b/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
@@ -6,7 +6,6 @@ import TableContainerUI from "@/components/common/Table/Composition/TableContain
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import ModalTooltipRoot from "@/components/common/Tooltip/ModalTooltip";
-import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import { ITrackInfo } from "@/types/dto";
 
 import styles from "./TrackListTable.module.scss";
@@ -36,15 +35,14 @@ const TrackListTable = ({ tracks }: TrackListTableProps) => {
                 {idx + 1}
               </TableCellUI>
               <TableCellUI>
-                {/* TODO: z-index 문제로 툴팁 안보임 */}
                 <ModalTooltipRoot message={track.koTrackName}>
                   <p className={cx("ellipsis")}>{track.koTrackName}</p>
                 </ModalTooltipRoot>
               </TableCellUI>
               <TableCellUI>
-                <TooltipRoot message={track.enTrackName}>
+                <ModalTooltipRoot message={track.enTrackName}>
                   <p className={cx("ellipsis")}>{track.enTrackName}</p>
-                </TooltipRoot>
+                </ModalTooltipRoot>
               </TableCellUI>
             </TableRowUI>
           );

--- a/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
+++ b/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
@@ -5,6 +5,7 @@ import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
+import ModalTooltipRoot from "@/components/common/Tooltip/ModalTooltip";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import { ITrackInfo } from "@/types/dto";
 
@@ -36,9 +37,9 @@ const TrackListTable = ({ tracks }: TrackListTableProps) => {
               </TableCellUI>
               <TableCellUI>
                 {/* TODO: z-index 문제로 툴팁 안보임 */}
-                <TooltipRoot message={track.koTrackName}>
+                <ModalTooltipRoot message={track.koTrackName}>
                   <p className={cx("ellipsis")}>{track.koTrackName}</p>
-                </TooltipRoot>
+                </ModalTooltipRoot>
               </TableCellUI>
               <TableCellUI>
                 <TooltipRoot message={track.enTrackName}>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
- dialog 모달에서 기존 Tooltip의 z-index의 영향을 받지 않는 이슈 해결
- 모달 내에선 따로 <ModalTooltipRoot> 컴포넌트를 사용하시면 됩니다.
- 기존 Tooltip과 달리, 이 컴포넌트는 따로 포탈화하지 않고, 그대로 Modal 컴포넌트 내에서 렌더링되는 식으로 구현했습니다

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/78773781/24daa1dc-c6e5-4a23-a82e-ce41b7b170da)
