### PR TITLE
BPS-241/변경 api 내용 반영 & DTO 필드명 통일 (BPS-236브랜치(=#90 PR) 후속 작업)

### DIFF
--- a/src/components/album/AlbumList/AlbumList.tsx
+++ b/src/components/album/AlbumList/AlbumList.tsx
@@ -25,7 +25,7 @@ const AlbumList = ({ userType, paginationElement }: AlbumListProps) => {
               key={album.albumId}
               albumId={album.albumId}
               albumCoverUrl={album.albumImage}
-              albumTitle={album.koAlbumName}
+              albumTitle={album.name}
               hasOptionsButton={userType !== MEMBER_TYPE.ADMIN}
             />
           );

--- a/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
+++ b/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
@@ -55,10 +55,10 @@ const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
                   return (
                     <>
                       <TooltipRoot
-                        message={participant.koArtistName}
-                        key={participant.koArtistName}
+                        message={participant.name}
+                        key={participant.name}
                       >
-                        <p className={cx("ellipsis")}>{participant.koArtistName}</p>
+                        <p className={cx("ellipsis")}>{participant.name}</p>
                       </TooltipRoot>
                       <br />
                     </>
@@ -68,7 +68,7 @@ const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
               <TableCellUI>
                 {item.participants.map((participant) => {
                   return (
-                    <p key={participant.koArtistName}>{`${participant.commissionRate}%`}</p>
+                    <p key={participant.name}>{`${participant.commissionRate}%`}</p>
                   );
                 })}
               </TableCellUI>

--- a/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
+++ b/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
@@ -38,16 +38,16 @@ const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
       <TableBodyUI>
         {tracks.map((item, index) => {
           return (
-            <TableRowUI key={item.koTrackName}>
+            <TableRowUI key={item.name}>
               <TableCellUI>{index + 1}</TableCellUI>
               <TableCellUI>
-                <TooltipRoot message={item.koTrackName}>
-                  <p className={cx("ellipsis")}>{item.koTrackName}</p>
+                <TooltipRoot message={item.name}>
+                  <p className={cx("ellipsis")}>{item.name}</p>
                 </TooltipRoot>
               </TableCellUI>
               <TableCellUI>
-                <TooltipRoot message={item.enTrackName}>
-                  <p className={cx("ellipsis")}>{item.enTrackName}</p>
+                <TooltipRoot message={item.enName}>
+                  <p className={cx("ellipsis")}>{item.enName}</p>
                 </TooltipRoot>
               </TableCellUI>
               <TableCellUI>

--- a/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
+++ b/src/components/artist/ArtistsStatusTable/ArtistsStatusTable.tsx
@@ -52,9 +52,9 @@ const ArtistsStatusTable = ({
               </TableCellUI>
               <TableCellUI>
                 <Link href={`/artist/${artistInfo.artist.memberId}/dashboard`} className={cx("artistNameSection")}>
-                  <TooltipRoot message={artistInfo.artist.koArtistName}>
-                    <p className={cx("artistName", "ellipsis")}>{artistInfo.artist.koArtistName}</p>
-                    <p className={cx("artistName", "enName", "ellipsis")}>{artistInfo.artist.enArtistName}</p>
+                  <TooltipRoot message={artistInfo.artist.name}>
+                    <p className={cx("artistName", "ellipsis")}>{artistInfo.artist.name}</p>
+                    <p className={cx("artistName", "enName", "ellipsis")}>{artistInfo.artist.enName}</p>
                   </TooltipRoot>
                 </Link>
               </TableCellUI>

--- a/src/components/common/Chart/BarChart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart/BarChart.tsx
@@ -1,7 +1,8 @@
 import { ResponsiveBar } from "@nivo/bar";
 import classNames from "classnames/bind";
 
-import { IGetAdminMonthlyEarningsTrendsResponse, IGetArtistMonthlyEarningsTrendsResponse } from "@/services/api/types/admin";
+import { IGetAdminMonthlyTrendsResponse } from "@/services/api/types/admin";
+import { IGetArtistMonthlyTrendsResponse } from "@/services/api/types/artist";
 import { MEMBER_ROLE, MemberRole } from "@/types/enums/user.enum";
 import formatMoney from "@/utils/formatMoney";
 
@@ -44,7 +45,7 @@ const yAxisFormat = (item: number) => {
  * @param type - MEMBER_TYPE
 */
 const BarChart = ({ barChartData, type }: {
-  barChartData: IGetAdminMonthlyEarningsTrendsResponse | IGetArtistMonthlyEarningsTrendsResponse,
+  barChartData: IGetAdminMonthlyTrendsResponse | IGetArtistMonthlyTrendsResponse,
   type: MemberRole
 }) => {
   const maxValue: number = getMaxValue(barChartData, type);

--- a/src/components/common/Chart/BarChart/BarChart.utils.ts
+++ b/src/components/common/Chart/BarChart/BarChart.utils.ts
@@ -1,4 +1,5 @@
-import { IGetAdminMonthlyEarningsTrendsResponse, IGetArtistMonthlyEarningsTrendsResponse } from "@/services/api/types/admin";
+import { IGetAdminMonthlyTrendsResponse } from "@/services/api/types/admin";
+import { IGetArtistMonthlyTrendsResponse } from "@/services/api/types/artist";
 import { MEMBER_ROLE, MemberRole } from "@/types/enums/user.enum";
 
 const monthNames: { [key: number]: string } = {
@@ -24,7 +25,7 @@ export const getMonthName = (num: number): string => {
 };
 
 export const mapChartDataToMonthlySummary = (
-  chartData: IGetAdminMonthlyEarningsTrendsResponse | IGetArtistMonthlyEarningsTrendsResponse,
+  chartData: IGetAdminMonthlyTrendsResponse | IGetArtistMonthlyTrendsResponse,
   type: MemberRole,
 ) => {
   const convertedBarChartData = chartData.contents.map((data) => {
@@ -35,17 +36,18 @@ export const mapChartDataToMonthlySummary = (
         revenue: data.revenue,
       };
     }
-    if ("netIncome" in data) {
-      return { month: getMonthName(data.month), netIncome: data.netIncome, revenue: data.revenue };
-    }
-    return { month: getMonthName(data.month), revenue: data.revenue };
+    return {
+      month: getMonthName(data.month),
+      netIncome: data.netIncome,
+      revenue: data.revenue,
+    };
   });
 
   return convertedBarChartData; // 함수에서 변환된 데이터를 반환
 };
 
 export const getMaxValue = (
-  chartData: IGetAdminMonthlyEarningsTrendsResponse | IGetArtistMonthlyEarningsTrendsResponse,
+  chartData: IGetAdminMonthlyTrendsResponse | IGetArtistMonthlyTrendsResponse,
   type: MemberRole,
 ): number => {
   let maxValue = 0;

--- a/src/components/common/Chart/DoughnutChart/DoughnutChart.utils.ts
+++ b/src/components/common/Chart/DoughnutChart/DoughnutChart.utils.ts
@@ -15,13 +15,13 @@ export const createChartDataFromContents = (doughnutData: DoughnutData): ChartDa
     if ("artist" in chartItem) {
       return {
         id: chartItem.artist.memberId.toString(),
-        label: chartItem.artist.koArtistName,
+        label: chartItem.artist.name,
         value: chartItem.proportion,
       };
     }
     return {
       id: chartItem.track.trackId.toString(),
-      label: chartItem.track.koTrackName,
+      label: chartItem.track.name,
       value: chartItem.proportion,
     };
   });

--- a/src/components/common/Chart/LineChart/LineChart.utils.ts
+++ b/src/components/common/Chart/LineChart/LineChart.utils.ts
@@ -18,7 +18,7 @@ export const mapLineDataToMonthlySummary = (
   memberRole: MemberRole,
 ) => {
   const data = {
-    id: chartData.koTrackName,
+    id: chartData.name,
     data: chartData.monthlyTrend.map((chartItem) => {
       return {
         x: getMonthName(chartItem.month),

--- a/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.tsx
+++ b/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.tsx
@@ -36,11 +36,11 @@ const AlbumInfoModal = ({
                 alt="앨범 커버"
               />
             </div>
-            <h3 className={cx("albumTitle")}>{data.koAlbumName}</h3>
+            <h3 className={cx("albumTitle")}>{data.name}</h3>
             <hr className={cx("hr")} />
             <div className={cx("artist")}>
-              <span className={cx("name")}>{data.artist?.koArtistName}</span>
-              <span className={cx("name", "enName")}>{data.artist?.enArtistName}</span>
+              <span className={cx("name")}>{data.artist?.name}</span>
+              <span className={cx("name", "enName")}>{data.artist?.enName}</span>
             </div>
           </div>
           <div className={cx("tableWrapper")}>

--- a/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
+++ b/src/components/dashboard/AlbumInfoModal/TrackListTable/TrackListTable.tsx
@@ -35,13 +35,13 @@ const TrackListTable = ({ tracks }: TrackListTableProps) => {
                 {idx + 1}
               </TableCellUI>
               <TableCellUI>
-                <ModalTooltipRoot message={track.koTrackName}>
-                  <p className={cx("ellipsis")}>{track.koTrackName}</p>
+                <ModalTooltipRoot message={track.name}>
+                  <p className={cx("ellipsis")}>{track.name}</p>
                 </ModalTooltipRoot>
               </TableCellUI>
               <TableCellUI>
-                <ModalTooltipRoot message={track.enTrackName}>
-                  <p className={cx("ellipsis")}>{track.enTrackName}</p>
+                <ModalTooltipRoot message={track.enName}>
+                  <p className={cx("ellipsis")}>{track.enName}</p>
                 </ModalTooltipRoot>
               </TableCellUI>
             </TableRowUI>

--- a/src/components/dashboard/AlbumTrendsChart/AlbumTrendsChart.tsx
+++ b/src/components/dashboard/AlbumTrendsChart/AlbumTrendsChart.tsx
@@ -22,7 +22,7 @@ interface AlbumTrendsChartProps {
  * @param memberRole - SUPER_ADMIN | ADMIN | ARTIST
 */
 const AlbumTrendsChart = ({ albumTrendsChartData, memberRole }: AlbumTrendsChartProps) => {
-  const trackList = albumTrendsChartData.tracks.map((track) => { return track.koTrackName; });
+  const trackList = albumTrendsChartData.tracks.map((track) => { return track.name; });
   const [selectedTrack, setSelectedTrack] = useState(trackList[0]);
 
   const handleSelectedTrack = (value: string) => {
@@ -30,7 +30,7 @@ const AlbumTrendsChart = ({ albumTrendsChartData, memberRole }: AlbumTrendsChart
   };
 
   const selectedTrackTrandsList = albumTrendsChartData.tracks.find(
-    (track) => { return track.koTrackName === selectedTrack; },
+    (track) => { return track.name === selectedTrack; },
   );
 
   if (!selectedTrackTrandsList) {

--- a/src/components/dashboard/AlbumTrendsChart/AlbumTrendsChart.tsx
+++ b/src/components/dashboard/AlbumTrendsChart/AlbumTrendsChart.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import classNames from "classnames/bind";
 
-import { IGetAlbumTrackSettlementTrendsResponse } from "@/services/api/types/albums";
+import { IGetAlbumTracksTrendsResponse } from "@/services/api/types/albums";
 import { MEMBER_ROLE, MemberRole } from "@/types/enums/user.enum";
 
 import LineChart from "../../common/Chart/LineChart/LineChart";
@@ -13,7 +13,7 @@ import styles from "./AlbumTrendsChart.module.scss";
 const cx = classNames.bind(styles);
 
 interface AlbumTrendsChartProps {
-  albumTrendsChartData: IGetAlbumTrackSettlementTrendsResponse,
+  albumTrendsChartData: IGetAlbumTracksTrendsResponse,
   memberRole: MemberRole,
 }
 /**

--- a/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
+++ b/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
@@ -2,7 +2,8 @@ import classNames from "classnames/bind";
 import dynamic from "next/dynamic";
 
 import CustomLegend from "@/components/common/CustomLegend/CustomLegend";
-import { IGetAdminMonthlyEarningsTrendsResponse, IGetArtistMonthlyEarningsTrendsResponse } from "@/services/api/types/admin";
+import { IGetAdminMonthlyTrendsResponse } from "@/services/api/types/admin";
+import { IGetArtistMonthlyTrendsResponse } from "@/services/api/types/artist";
 import { MEMBER_ROLE, MemberRole } from "@/types/enums/user.enum";
 
 import styles from "./MonthlyTrendsChart.module.scss";
@@ -10,7 +11,7 @@ import styles from "./MonthlyTrendsChart.module.scss";
 const cx = classNames.bind(styles);
 
 interface MonthlyTrendChartProps {
-  barChartData: IGetAdminMonthlyEarningsTrendsResponse | IGetArtistMonthlyEarningsTrendsResponse,
+  barChartData: IGetAdminMonthlyTrendsResponse | IGetArtistMonthlyTrendsResponse,
   type: MemberRole,
 }
 const DynamicBarChart = dynamic(() => { return import("@/components/common/Chart/BarChart/BarChart"); }, { ssr: false });

--- a/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChartLegend.tsx
+++ b/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChartLegend.tsx
@@ -17,7 +17,7 @@ interface TopFiveChartLegendProps {
 
 const TopFiveRevenueChartLegend = ({ legendData, index }: TopFiveChartLegendProps) => {
   const isArtist = "artist" in legendData;
-  const legendText = isArtist ? legendData.artist.koArtistName : legendData.track.koTrackName;
+  const legendText = isArtist ? legendData.artist.name : legendData.track.name;
 
   return (
     <div key={index} className={cx("legendItem")}>

--- a/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
@@ -86,20 +86,20 @@ const AdminTrackStatusTable = ({
                 return (
                   <TableRowUI key={item.track.trackId}>
                     <TableCellUI>
-                      <TooltipRoot message={item.track.koTrackName}>
-                        <p className={cx("ellipsis")}>{item.track.koTrackName}</p>
+                      <TooltipRoot message={item.track.name}>
+                        <p className={cx("ellipsis")}>{item.track.name}</p>
                       </TooltipRoot>
                     </TableCellUI>
                     <TableCellUI>
-                      <TooltipRoot message={item.album.koAlbumName}>
-                        <p className={cx("ellipsis")}>{item.album.koAlbumName}</p>
+                      <TooltipRoot message={item.album.name}>
+                        <p className={cx("ellipsis")}>{item.album.name}</p>
                       </TooltipRoot>
                     </TableCellUI>
                     <TableCellUI>
                       <div>
                         <TooltipRoot message={formatArtistCell(item.artists)}>
                           <p className={cx("artistName", "ellipsis")}>{formatArtistCell(item.artists)}</p>
-                          <p className={cx("artistName", "enName", "ellipsis")}>{item.artists[0].enArtistName}</p>
+                          <p className={cx("artistName", "enName", "ellipsis")}>{item.artists[0].enName}</p>
                         </TooltipRoot>
                       </div>
                     </TableCellUI>

--- a/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
@@ -86,20 +86,20 @@ const ArtistTrackStatusTable = ({
                 return (
                   <TableRowUI key={item.track.trackId}>
                     <TableCellUI>
-                      <TooltipRoot message={item.track.koTrackName}>
-                        <p className={cx("ellipsis")}>{item.track.koTrackName}</p>
+                      <TooltipRoot message={item.track.name}>
+                        <p className={cx("ellipsis")}>{item.track.name}</p>
                       </TooltipRoot>
                     </TableCellUI>
                     <TableCellUI>
-                      <TooltipRoot message={item.album.koAlbumName}>
-                        <p className={cx("ellipsis")}>{item.album.koAlbumName}</p>
+                      <TooltipRoot message={item.album.name}>
+                        <p className={cx("ellipsis")}>{item.album.name}</p>
                       </TooltipRoot>
                     </TableCellUI>
                     <TableCellUI>
                       <div>
                         <TooltipRoot message={formatArtistCell(item.artists)}>
                           <p className={cx("artistName", "ellipsis")}>{formatArtistCell(item.artists)}</p>
-                          <p className={cx("artistName", "enName", "ellipsis")}>{item.artists[0].enArtistName}</p>
+                          <p className={cx("artistName", "enName", "ellipsis")}>{item.artists[0].enName}</p>
                         </TooltipRoot>
                       </div>
                     </TableCellUI>

--- a/src/components/dashboard/TrackStatusTable/TrackStatusTable.utils.ts
+++ b/src/components/dashboard/TrackStatusTable/TrackStatusTable.utils.ts
@@ -1,6 +1,6 @@
 import { IArtist } from "@/types/dto";
 
 export const formatArtistCell = (artists: IArtist[]) => {
-  if (artists.length > 1) return `${artists[0].koArtistName} 외 ${artists.length - 1}명`;
-  return artists[0].koArtistName;
+  if (artists.length > 1) return `${artists[0].name} 외 ${artists.length - 1}명`;
+  return artists[0].name;
 };

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -1,14 +1,14 @@
 import {
   IGetAdminDashboardResponse,
   IGetAdminEarningsTopArtistResponse,
-  IGetAdminMonthlyEarningsTrendsResponse,
+  IGetAdminMonthlyTrendsResponse,
   IGetAdminTrackTransactionResponse,
 } from "@/services/api/types/admin";
 import {
   IGetAlbumDashboardResponse,
-  IGetAlbumMonthlySettlementResponse,
+  IGetAlbumMonthlyTrendsResponse,
   IGetAlbumRevenueTopTrackResponse,
-  IGetAlbumTrackSettlementTrendsResponse,
+  IGetAlbumTracksTrendsResponse,
   IGetAlbumTracksResponse,
   IGetAlbumsResponse,
 } from "@/services/api/types/albums";
@@ -16,7 +16,7 @@ import {
   IGetArtistAlbumsResponse,
   IGetArtistDashboardResponse,
   IGetArtistEarningsTopTrackResponse,
-  IGetArtistMonthlySettlementResponse,
+  IGetArtistMonthlyTrendsResponse,
   IGetArtistTrackTransactionResponse,
   IGetArtistsResponse,
 } from "@/services/api/types/artist";
@@ -275,32 +275,36 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
   ],
 };
 
-export const MOCK_ALBUM_BAR: IGetAlbumMonthlySettlementResponse = {
+export const MOCK_ALBUM_BAR: IGetAlbumMonthlyTrendsResponse = {
   contents: [
     {
       month: 1,
       settlement: 2142344,
       revenue: 732143,
+      netIncome: 100000,
     },
     {
       month: 2,
       settlement: 2132459,
       revenue: 732392,
+      netIncome: 100000,
     },
     {
       month: 3,
       settlement: 1836935,
       revenue: 632143,
+      netIncome: 100000,
     },
     {
       month: 4,
       settlement: 5142344,
       revenue: 1032143,
+      netIncome: 100000,
     },
   ],
 };
 
-export const MOCK_ALBUM_LINE: IGetAlbumTrackSettlementTrendsResponse = {
+export const MOCK_ALBUM_LINE: IGetAlbumTracksTrendsResponse = {
   tracks: [
     {
       trackId: 1,
@@ -311,61 +315,73 @@ export const MOCK_ALBUM_LINE: IGetAlbumTrackSettlementTrendsResponse = {
           month: 1,
           settlement: 1442344,
           revenue: 832143,
+          netIncome: 100000,
         },
         {
           month: 2,
           settlement: 5932459,
           revenue: 332392,
+          netIncome: 100000,
         },
         {
           month: 3,
           settlement: 1936935,
           revenue: 632143,
+          netIncome: 100000,
         },
         {
           month: 4,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 5,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 6,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 7,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 8,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 9,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 10,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 11,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
         {
           month: 12,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
       ],
     },
@@ -378,21 +394,25 @@ export const MOCK_ALBUM_LINE: IGetAlbumTrackSettlementTrendsResponse = {
           month: 1,
           settlement: 2142344,
           revenue: 732143,
+          netIncome: 100000,
         },
         {
           month: 2,
           settlement: 2132459,
           revenue: 732392,
+          netIncome: 100000,
         },
         {
           month: 3,
           settlement: 1836935,
           revenue: 632143,
+          netIncome: 100000,
         },
         {
           month: 4,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
       ],
     },
@@ -405,21 +425,25 @@ export const MOCK_ALBUM_LINE: IGetAlbumTrackSettlementTrendsResponse = {
           month: 1,
           settlement: 2142344,
           revenue: 732143,
+          netIncome: 100000,
         },
         {
           month: 2,
           settlement: 2132459,
           revenue: 732392,
+          netIncome: 100000,
         },
         {
           month: 3,
           settlement: 1836935,
           revenue: 632143,
+          netIncome: 100000,
         },
         {
           month: 4,
           settlement: 5142344,
           revenue: 1032143,
+          netIncome: 100000,
         },
       ],
     },
@@ -580,7 +604,7 @@ export const MOCK_ADMIN_DASHBOARD_CARD: IGetAdminDashboardResponse = {
   },
 };
 
-export const MOCK_ADMIN_BAR: IGetAdminMonthlyEarningsTrendsResponse = {
+export const MOCK_ADMIN_BAR: IGetAdminMonthlyTrendsResponse = {
   contents: [
     {
       month: 1,
@@ -1043,27 +1067,31 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
   ],
 };
 
-export const MOCK_ARTIST_BAR: IGetArtistMonthlySettlementResponse = {
+export const MOCK_ARTIST_BAR: IGetArtistMonthlyTrendsResponse = {
   contents: [
     {
       month: 1,
       settlement: 2142344,
       revenue: 732143,
+      netIncome: 100000,
     },
     {
       month: 2,
       settlement: 2132459,
       revenue: 732392,
+      netIncome: 100000,
     },
     {
       month: 3,
       settlement: 1836935,
       revenue: 632143,
+      netIncome: 100000,
     },
     {
       month: 4,
       settlement: 5142344,
       revenue: 1032143,
+      netIncome: 100000,
     },
   ],
 };

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -506,7 +506,18 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
 };
 
 export const MOCK_ALBUM_DASHBOARD_CARD: IGetAlbumDashboardResponse = {
-  settlement:
+  albumId: 1,
+  koAlbumName: "미녀 OST",
+  enAlbumName: "미녀 OST",
+  revenue: {
+    totalAmount: 12345,
+    growthRate: 12345,
+  },
+  netIncome: {
+    totalAmount: 12345,
+    growthRate: 12345,
+  },
+  settlementAmount:
   {
     totalAmount: 1000,
     growthRate: 10.2,
@@ -919,7 +930,7 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
 };
 
 export const MOCK_ARTIST_DASHBOARD_CARD: IGetArtistDashboardResponse = {
-  settlement:
+  settlementAmount:
   {
     totalAmount: 1000,
     growthRate: 10.2,

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -86,14 +86,12 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
         {
           memberId: 1,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
           commissionRate: 50,
         },
       ],
@@ -106,8 +104,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -120,14 +117,12 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
         {
           memberId: 1,
-          koArtistName: "승희",
-          enArtistName: "Seunghee",
+          name: "승희",
           commissionRate: 30,
         },
       ],
@@ -140,8 +135,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -154,8 +148,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -168,14 +161,12 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
         {
           memberId: 1,
-          koArtistName: "승희",
-          enArtistName: "Seunghee",
+          name: "승희",
           commissionRate: 30,
         },
       ],
@@ -188,8 +179,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -202,8 +192,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -216,14 +205,12 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
         {
           memberId: 1,
-          koArtistName: "승희",
-          enArtistName: "Seunghee",
+          name: "승희",
           commissionRate: 30,
         },
       ],
@@ -236,8 +223,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -250,8 +236,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],
@@ -264,14 +249,12 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
         {
           memberId: 1,
-          koArtistName: "승희",
-          enArtistName: "Seunghee",
+          name: "승희",
           commissionRate: 30,
         },
       ],
@@ -284,8 +267,7 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
       participants: [
         {
           memberId: 1,
-          koArtistName: "아린",
-          enArtistName: "Arin",
+          name: "아린",
           commissionRate: 50,
         },
       ],

--- a/src/constants/mock.ts
+++ b/src/constants/mock.ts
@@ -30,37 +30,37 @@ export const MOCK_ALBUMS: IGetAlbumsResponse = {
     {
       albumId: 1,
       albumImage: "https://image.bugsm.co.kr/album/images/500/201408/20140893.jpg",
-      koAlbumName: "비밀정원",
+      name: "비밀정원",
       enName: "enName",
     },
     {
       albumId: 2,
       albumImage: "https://spnimage.edaily.co.kr/images/photo/files/NP/S/2023/05/PS23050700058.jpg",
-      koAlbumName: "클로저",
+      name: "클로저",
       enName: "enName",
     },
     {
       albumId: 3,
       albumImage: "https://cdn.obsnews.co.kr/news/photo/201605/974498_234531_5514.jpg",
-      koAlbumName: "윈디데이",
+      name: "윈디데이",
       enName: "enName",
     },
     {
       albumId: 4,
       albumImage: "https://image.bugsm.co.kr/album/images/500/201408/20140893.jpg",
-      koAlbumName: "번지",
+      name: "번지",
       enName: "enName",
     },
     {
       albumId: 5,
       albumImage: "https://spnimage.edaily.co.kr/images/photo/files/NP/S/2023/05/PS23050700058.jpg",
-      koAlbumName: "던던댄스",
+      name: "던던댄스",
       enName: "enName",
     },
     {
       albumId: 6,
       albumImage: "https://cdn.obsnews.co.kr/news/photo/201605/974498_234531_5514.jpg",
-      koAlbumName: "살짝설렜어",
+      name: "살짝설렜어",
       enName: "enName",
     },
   ],
@@ -69,19 +69,19 @@ export const MOCK_ALBUMS: IGetAlbumsResponse = {
 export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
   albumId: 1,
   albumImage: "https://image.bugsm.co.kr/album/images/500/201408/20140893.jpg",
-  koAlbumName: "비밀정원",
-  enAlbumName: "Secret Garden",
+  name: "비밀정원",
+  enName: "Secret Garden",
   artist:
   {
     memberId: 1,
-    koArtistName: "오마이걸",
-    enArtistName: "Ohmygirl",
+    name: "오마이걸",
+    enName: "Ohmygirl",
   },
   tracks: [
     {
       trackId: 1,
-      koTrackName: "불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이불꽃놀이",
+      enName: "Fireworks",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -98,8 +98,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 2,
-      koTrackName: "던던댄스",
-      enTrackName: "Dun Dun Dance",
+      name: "던던댄스",
+      enName: "Dun Dun Dance",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -111,8 +111,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 3,
-      koTrackName: "바나나 알러지 원숭이",
-      enTrackName: "Banana Allergy Monkey",
+      name: "바나나 알러지 원숭이",
+      enName: "Banana Allergy Monkey",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -129,8 +129,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 4,
-      koTrackName: "불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이",
+      enName: "Fireworks",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -142,8 +142,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 5,
-      koTrackName: "던던댄스",
-      enTrackName: "Dun Dun Dance",
+      name: "던던댄스",
+      enName: "Dun Dun Dance",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -155,8 +155,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 6,
-      koTrackName: "바나나 알러지 원숭이",
-      enTrackName: "Banana Allergy Monkey",
+      name: "바나나 알러지 원숭이",
+      enName: "Banana Allergy Monkey",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -173,8 +173,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 7,
-      koTrackName: "불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이",
+      enName: "Fireworks",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -186,8 +186,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 8,
-      koTrackName: "던던댄스",
-      enTrackName: "Dun Dun Dance",
+      name: "던던댄스",
+      enName: "Dun Dun Dance",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -199,8 +199,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 9,
-      koTrackName: "바나나 알러지 원숭이",
-      enTrackName: "Banana Allergy Monkey",
+      name: "바나나 알러지 원숭이",
+      enName: "Banana Allergy Monkey",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -217,8 +217,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 10,
-      koTrackName: "불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이",
+      enName: "Fireworks",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -230,8 +230,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 11,
-      koTrackName: "던던댄스",
-      enTrackName: "Dun Dun Dance",
+      name: "던던댄스",
+      enName: "Dun Dun Dance",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -243,8 +243,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 12,
-      koTrackName: "바나나 알러지 원숭이",
-      enTrackName: "Banana Allergy Monkey",
+      name: "바나나 알러지 원숭이",
+      enName: "Banana Allergy Monkey",
       bluekeyOriginalTrack: true,
       participants: [
         {
@@ -261,8 +261,8 @@ export const MOCK_ALBUM_TRACKS: IGetAlbumTracksResponse = {
     },
     {
       trackId: 13,
-      koTrackName: "불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이",
+      enName: "Fireworks",
       bluekeyOriginalTrack: false,
       participants: [
         {
@@ -308,8 +308,8 @@ export const MOCK_ALBUM_LINE: IGetAlbumTracksTrendsResponse = {
   tracks: [
     {
       trackId: 1,
-      koTrackName: "불꽃놀이",
-      enTrackName: "Fireworks",
+      name: "불꽃놀이",
+      enName: "Fireworks",
       monthlyTrend: [
         {
           month: 1,
@@ -387,8 +387,8 @@ export const MOCK_ALBUM_LINE: IGetAlbumTracksTrendsResponse = {
     },
     {
       trackId: 1,
-      koTrackName: "던던댄스",
-      enTrackName: "Dun Dun Dance",
+      name: "던던댄스",
+      enName: "Dun Dun Dance",
       monthlyTrend: [
         {
           month: 1,
@@ -418,8 +418,8 @@ export const MOCK_ALBUM_LINE: IGetAlbumTracksTrendsResponse = {
     },
     {
       trackId: 1,
-      koTrackName: "바나나 알러지 원숭이",
-      enTrackName: "Banana Allergy Monkey",
+      name: "바나나 알러지 원숭이",
+      enName: "Banana Allergy Monkey",
       monthlyTrend: [
         {
           month: 1,
@@ -455,8 +455,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
     {
       track: {
         trackId: 1,
-        koTrackName: "트랙1",
-        enTrackName: "track1",
+        name: "트랙1",
+        enName: "track1",
       },
       revenue: 1000000,
       growthRate: 2.1,
@@ -465,8 +465,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
     {
       track: {
         trackId: 2,
-        koTrackName: "트랙2",
-        enTrackName: "track2",
+        name: "트랙2",
+        enName: "track2",
       },
       revenue: 800000,
       growthRate: 6.1,
@@ -475,8 +475,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
     {
       track: {
         trackId: 3,
-        koTrackName: "트랙3",
-        enTrackName: "track3",
+        name: "트랙3",
+        enName: "track3",
       },
       revenue: 600000,
       growthRate: -25.1,
@@ -485,8 +485,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
     {
       track: {
         trackId: 4,
-        koTrackName: "트랙4",
-        enTrackName: "track4",
+        name: "트랙4",
+        enName: "track4",
       },
       revenue: 40000,
       growthRate: -13,
@@ -495,8 +495,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
     {
       track: {
         trackId: 5,
-        koTrackName: "트랙5",
-        enTrackName: "track5",
+        name: "트랙5",
+        enName: "track5",
       },
       revenue: 300,
       growthRate: 2.5,
@@ -507,8 +507,8 @@ export const MOCK_ALBUM_DOUGHNUT: IGetAlbumRevenueTopTrackResponse = {
 
 export const MOCK_ALBUM_DASHBOARD_CARD: IGetAlbumDashboardResponse = {
   albumId: 1,
-  koAlbumName: "미녀 OST",
-  enAlbumName: "미녀 OST",
+  name: "미녀 OST",
+  enName: "미녀 OST",
   revenue: {
     totalAmount: 12345,
     growthRate: 12345,
@@ -525,8 +525,8 @@ export const MOCK_ALBUM_DASHBOARD_CARD: IGetAlbumDashboardResponse = {
   bestTrack:
   {
     trackId: 1,
-    koTrackName: "트랙명2",
-    enTrackName: "track2",
+    name: "트랙명2",
+    enName: "track2",
     growthRate: -30,
   },
 };
@@ -609,8 +609,8 @@ export const MOCK_ADMIN_DASHBOARD_CARD: IGetAdminDashboardResponse = {
   },
   bestArtist: {
     memberId: 1,
-    koArtistName: "아이유",
-    enArtistName: "IU",
+    name: "아이유",
+    enName: "IU",
     growthRate: 0.3,
   },
 };
@@ -657,29 +657,29 @@ export const MOCK_ADMIN_TABLE: IGetAdminTrackTransactionResponse = {
     {
       track: {
         trackId: 1,
-        koTrackName: "이름이 아주아주 매우매우 베리베리 긴 곡",
-        enTrackName: "track name",
+        name: "이름이 아주아주 매우매우 베리베리 긴 곡",
+        enName: "track name",
       },
       album: {
         albumId: 1,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 1,
-          koArtistName: "아이유~~참말로제가한게아닙니더",
-          enArtistName: "IU",
+          name: "아이유~~참말로제가한게아닙니더",
+          enName: "IU",
         },
         {
           memberId: 2,
-          koArtistName: "지드래곤",
-          enArtistName: "G-Dragon",
+          name: "지드래곤",
+          enName: "G-Dragon",
         },
         {
           memberId: 3,
-          koArtistName: "태양",
-          enArtistName: "Sun",
+          name: "태양",
+          enName: "Sun",
         },
       ],
       revenue: 1000000000,
@@ -690,19 +690,19 @@ export const MOCK_ADMIN_TABLE: IGetAdminTrackTransactionResponse = {
     {
       track: {
         trackId: 2,
-        koTrackName: "곡 제목",
-        enTrackName: "track name",
+        name: "곡 제목",
+        enName: "track name",
       },
       album: {
         albumId: 2,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 2,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
+          enName: "IU",
         },
       ],
       revenue: 17831413,
@@ -713,19 +713,19 @@ export const MOCK_ADMIN_TABLE: IGetAdminTrackTransactionResponse = {
     {
       track: {
         trackId: 3,
-        koTrackName: "곡 제목",
-        enTrackName: "track name",
+        name: "곡 제목",
+        enName: "track name",
       },
       album: {
         albumId: 3,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 3,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
+          enName: "IU",
         },
       ],
       revenue: 12,
@@ -741,8 +741,8 @@ export const MOCK_ADMIN_DOUGHNUT: IGetAdminEarningsTopArtistResponse = {
     {
       artist: {
         memberId: 1,
-        koArtistName: "아이유",
-        enArtistName: "IU",
+        name: "아이유",
+        enName: "IU",
       },
       revenue: 1000000000,
       growthRate: 250,
@@ -751,8 +751,8 @@ export const MOCK_ADMIN_DOUGHNUT: IGetAdminEarningsTopArtistResponse = {
     {
       artist: {
         memberId: 2,
-        koArtistName: "정국",
-        enArtistName: "Jungkuk",
+        name: "정국",
+        enName: "Jungkuk",
       },
       revenue: 10000000,
       growthRate: 24,
@@ -761,8 +761,8 @@ export const MOCK_ADMIN_DOUGHNUT: IGetAdminEarningsTopArtistResponse = {
     {
       artist: {
         memberId: 3,
-        koArtistName: "혁기",
-        enArtistName: "Hyucki",
+        name: "혁기",
+        enName: "Hyucki",
       },
       revenue: 10000,
       growthRate: 25,
@@ -771,8 +771,8 @@ export const MOCK_ADMIN_DOUGHNUT: IGetAdminEarningsTopArtistResponse = {
     {
       artist: {
         memberId: 4,
-        koArtistName: "SKY",
-        enArtistName: "SKY",
+        name: "SKY",
+        enName: "SKY",
       },
       revenue: 500,
       growthRate: -300,
@@ -781,8 +781,8 @@ export const MOCK_ADMIN_DOUGHNUT: IGetAdminEarningsTopArtistResponse = {
     {
       artist: {
         memberId: 5,
-        koArtistName: "지미 가드너",
-        enArtistName: "Jimmi Gardener",
+        name: "지미 가드너",
+        enName: "Jimmi Gardener",
       },
       revenue: 300,
       growthRate: 0,
@@ -799,8 +799,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 1,
-        koArtistName: "김블루김블루김블루김블루김블루",
-        enArtistName: "bluekeybluekeybluekeybluekey",
+        name: "김블루김블루김블루김블루김블루",
+        enName: "bluekeybluekeybluekeybluekey",
         profileImage: null,
       },
       revenue: 300,
@@ -812,8 +812,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 2,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -825,8 +825,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 3,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -838,8 +838,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 4,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: null,
       },
       revenue: 300,
@@ -851,8 +851,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 5,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: null,
       },
       revenue: 300,
@@ -864,8 +864,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 6,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -877,8 +877,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 7,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -890,8 +890,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 8,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: null,
       },
       revenue: 300,
@@ -903,8 +903,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 9,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -916,8 +916,8 @@ export const MOCK_ARTISTS: IGetArtistsResponse = {
     {
       artist: {
         memberId: 10,
-        koArtistName: "김블루",
-        enArtistName: "bluekey",
+        name: "김블루",
+        enName: "bluekey",
         profileImage: "https://biz.chosun.com/resizer/CMMnrLVaHCUa7dMliL1X58L4ah8=/530x640/smart/cloudfront-ap-northeast-1.images.arcpublishing.com/chosunbiz/WVRMPWAH7BOOJOZCMEKRV4CX5U.jpg",
       },
       revenue: 300,
@@ -938,15 +938,15 @@ export const MOCK_ARTIST_DASHBOARD_CARD: IGetArtistDashboardResponse = {
   bestAlbum:
   {
     albumId: 1,
-    koAlbumName: "앨범명2",
-    enAlbumName: "album2",
+    name: "앨범명2",
+    enName: "album2",
     growthRate: 300,
   },
   bestTrack:
   {
     trackId: 1,
-    koTrackName: "트랙명2",
-    enTrackName: "track2",
+    name: "트랙명2",
+    enName: "track2",
     growthRate: -30,
   },
 };
@@ -957,19 +957,19 @@ export const MOCK_ARTIST_TABLE: IGetArtistTrackTransactionResponse = {
     {
       track: {
         trackId: 1,
-        koTrackName: "아주아주 이름이 매우매우 긴 곡",
-        enTrackName: "track name",
+        name: "아주아주 이름이 매우매우 긴 곡",
+        enName: "track name",
       },
       album: {
         albumId: 1,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 1,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
+          enName: "IU",
         },
       ],
       revenue: 1000000000,
@@ -979,19 +979,19 @@ export const MOCK_ARTIST_TABLE: IGetArtistTrackTransactionResponse = {
     {
       track: {
         trackId: 2,
-        koTrackName: "곡 제목",
-        enTrackName: "track name",
+        name: "곡 제목",
+        enName: "track name",
       },
       album: {
         albumId: 2,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 2,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
+          enName: "IU",
         },
       ],
       revenue: 17831413,
@@ -1001,19 +1001,19 @@ export const MOCK_ARTIST_TABLE: IGetArtistTrackTransactionResponse = {
     {
       track: {
         trackId: 3,
-        koTrackName: "곡 제목",
-        enTrackName: "track name",
+        name: "곡 제목",
+        enName: "track name",
       },
       album: {
         albumId: 3,
-        koAlbumName: "앨범 이름",
-        enAlbumName: "Album name",
+        name: "앨범 이름",
+        enName: "Album name",
       },
       artists: [
         {
           memberId: 3,
-          koArtistName: "아이유",
-          enArtistName: "IU",
+          name: "아이유",
+          enName: "IU",
         },
       ],
       revenue: 12,
@@ -1028,8 +1028,8 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
     {
       track: {
         trackId: 1,
-        koTrackName: "트랙1",
-        enTrackName: "track1",
+        name: "트랙1",
+        enName: "track1",
       },
       revenue: 1000000,
       growthRate: 2.1,
@@ -1038,8 +1038,8 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
     {
       track: {
         trackId: 2,
-        koTrackName: "트랙2",
-        enTrackName: "track2",
+        name: "트랙2",
+        enName: "track2",
       },
       revenue: 800000,
       growthRate: 6.1,
@@ -1048,8 +1048,8 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
     {
       track: {
         trackId: 3,
-        koTrackName: "트랙3",
-        enTrackName: "track3",
+        name: "트랙3",
+        enName: "track3",
       },
       revenue: 600000,
       growthRate: -25.1,
@@ -1058,8 +1058,8 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
     {
       track: {
         trackId: 4,
-        koTrackName: "트랙4",
-        enTrackName: "track4",
+        name: "트랙4",
+        enName: "track4",
       },
       revenue: 40000,
       growthRate: -13,
@@ -1068,8 +1068,8 @@ export const MOCK_ARTIST_DOUGHNUT: IGetArtistEarningsTopTrackResponse = {
     {
       track: {
         trackId: 5,
-        koTrackName: "트랙5",
-        enTrackName: "track5",
+        name: "트랙5",
+        enName: "track5",
       },
       revenue: 300,
       growthRate: 2.5,
@@ -1113,37 +1113,37 @@ export const MOCK_ARTIST_ALBUMS: IGetArtistAlbumsResponse = {
     {
       albumId: 1,
       albumImage: "https://image.bugsm.co.kr/album/images/500/201408/20140893.jpg",
-      koAlbumName: "비밀정원",
+      name: "비밀정원",
       enName: "enName",
     },
     {
       albumId: 2,
       albumImage: "https://spnimage.edaily.co.kr/images/photo/files/NP/S/2023/05/PS23050700058.jpg",
-      koAlbumName: "클로저",
+      name: "클로저",
       enName: "enName",
     },
     {
       albumId: 3,
       albumImage: "https://cdn.obsnews.co.kr/news/photo/201605/974498_234531_5514.jpg",
-      koAlbumName: "윈디데이",
+      name: "윈디데이",
       enName: "enName",
     },
     {
       albumId: 4,
       albumImage: "https://image.bugsm.co.kr/album/images/500/201408/20140893.jpg",
-      koAlbumName: "번지",
+      name: "번지",
       enName: "enName",
     },
     {
       albumId: 5,
       albumImage: "https://spnimage.edaily.co.kr/images/photo/files/NP/S/2023/05/PS23050700058.jpg",
-      koAlbumName: "던던댄스",
+      name: "던던댄스",
       enName: "enName",
     },
     {
       albumId: 6,
       albumImage: "https://cdn.obsnews.co.kr/news/photo/201605/974498_234531_5514.jpg",
-      koAlbumName: "살짝설렜어",
+      name: "살짝설렜어",
       enName: "enName",
     },
   ],

--- a/src/pages/albums/[albumId]/[month]/index.page.tsx
+++ b/src/pages/albums/[albumId]/[month]/index.page.tsx
@@ -44,7 +44,7 @@ const AlbumDashboardPage = ({ month, albumId }: InferGetServerSidePropsType<GetS
   return (
     <section className={cx("container")}>
       <div className={cx("sectionHeader")}>
-        <h1 className={cx("title")}>{albumInfoQuery.data!.koAlbumName}</h1>
+        <h1 className={cx("title")}>{albumInfoQuery.data!.name}</h1>
         {memberRole === MEMBER_ROLE.ARTIST && <AlbumDetailsInformationTooltip />}
         <div className={cx("monthPickerDropdownContainer", { artist: memberRole === MEMBER_ROLE.ARTIST })}>
           <MonthPickerDropdown />

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -25,13 +25,13 @@ export const getArtistAccounts = async (page: number, size: number) => {
 
 /* 어드민 대시보드 카드 내용 */
 export const getAdminDashboardCards = async (month: string) => {
-  const response = await getRequest<IGetAdminDashboardResponse>(`/admin/dashboard?monthly=${convertYearMonthToQuery(month)}`);
+  const response = await getRequest<IGetAdminDashboardResponse>(`/admin/dashboard/summary?monthly=${convertYearMonthToQuery(month)}`);
   return response;
 };
 
 /* 어드민 대시보드 도넛 차트 내용 */
 export const getAdminDashboardDoughnut = async (month: string, rank: number) => {
-  const response = await getRequest<IGetAdminEarningsTopArtistResponse>(`/admin/dashboard/artist?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
+  const response = await getRequest<IGetAdminEarningsTopArtistResponse>(`/admin/dashboard/artist/top-track?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
   return response;
 };
 
@@ -45,7 +45,7 @@ export const getAdminDashboardTable = async (
   keyword: string | null,
 ) => {
   const response = await getRequest<IGetAdminTrackTransactionResponse>(
-    `/admin/dashboard/track?monthly=${convertYearMonthToQuery(month)}&page=${page}&size=${size}&sortBy=${sortBy}&searchBy=${searchBy}&keyword=${keyword ?? ""}`,
+    `/admin/dashboard/track?monthly=${convertYearMonthToQuery(month)}&page=${page}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword ?? ""}`,
   );
   return response;
 };

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -1,4 +1,4 @@
-import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthPicker.util";
+import convertYearMonthToQuery from "@/utils/convertYearMonthToQuery";
 
 import {
   IGetAdminAccountsResponse,
@@ -25,13 +25,13 @@ export const getArtistAccounts = async (page: number, size: number) => {
 
 /* 어드민 대시보드 카드 내용 */
 export const getAdminDashboardCards = async (month: string) => {
-  const response = await getRequest<IGetAdminDashboardResponse>(`/admin/dashboard?monthly=${convertToYearMonthFormat(month)}`);
+  const response = await getRequest<IGetAdminDashboardResponse>(`/admin/dashboard?monthly=${convertYearMonthToQuery(month)}`);
   return response;
 };
 
 /* 어드민 대시보드 도넛 차트 내용 */
 export const getAdminDashboardDoughnut = async (month: string, rank: number) => {
-  const response = await getRequest<IGetAdminEarningsTopArtistResponse>(`/admin/dashboard/artist?monthly=${convertToYearMonthFormat(month)}&rank=${rank}`);
+  const response = await getRequest<IGetAdminEarningsTopArtistResponse>(`/admin/dashboard/artist?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
   return response;
 };
 
@@ -45,14 +45,14 @@ export const getAdminDashboardTable = async (
   keyword: string | null,
 ) => {
   const response = await getRequest<IGetAdminTrackTransactionResponse>(
-    `/admin/dashboard/track?monthly=${convertToYearMonthFormat(month)}&page=${page}&size=${size}&sortBy=${sortBy}&searchBy=${searchBy}&keyword=${keyword ?? ""}`,
+    `/admin/dashboard/track?monthly=${convertYearMonthToQuery(month)}&page=${page}&size=${size}&sortBy=${sortBy}&searchBy=${searchBy}&keyword=${keyword ?? ""}`,
   );
   return response;
 };
 
 /* 어드민 대시보드 막대 차트 내용 */
 export const getAdminDashboardBar = async (startDate: string, endDate: string) => {
-  const response = await getRequest<IGetAdminMonthlyTrendsResponse>(`/admin/dashboard/trend?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
+  const response = await getRequest<IGetAdminMonthlyTrendsResponse>(`/admin/dashboard/trend?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
   return response;
 };
 

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -4,7 +4,7 @@ import {
   IGetAdminAccountsResponse,
   IGetAdminDashboardResponse,
   IGetAdminEarningsTopArtistResponse,
-  IGetAdminMonthlyEarningsTrendsResponse,
+  IGetAdminMonthlyTrendsResponse,
   IGetAdminProfileResponse,
   IGetAdminTrackTransactionResponse,
   IGetArtistAccountsResponse,
@@ -52,7 +52,7 @@ export const getAdminDashboardTable = async (
 
 /* 어드민 대시보드 막대 차트 내용 */
 export const getAdminDashboardBar = async (startDate: string, endDate: string) => {
-  const response = await getRequest<IGetAdminMonthlyEarningsTrendsResponse>(`/admin/dashboard/trend?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
+  const response = await getRequest<IGetAdminMonthlyTrendsResponse>(`/admin/dashboard/trend?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
   return response;
 };
 

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -5,6 +5,7 @@ import {
   IGetAdminDashboardResponse,
   IGetAdminEarningsTopArtistResponse,
   IGetAdminMonthlyEarningsTrendsResponse,
+  IGetAdminProfileResponse,
   IGetAdminTrackTransactionResponse,
   IGetArtistAccountsResponse,
 } from "../../types/admin";
@@ -52,5 +53,17 @@ export const getAdminDashboardTable = async (
 /* 어드민 대시보드 막대 차트 내용 */
 export const getAdminDashboardBar = async (startDate: string, endDate: string) => {
   const response = await getRequest<IGetAdminMonthlyEarningsTrendsResponse>(`/admin/dashboard/trend?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
+  return response;
+};
+
+/* 어드민 본인의 프로필 조회 */
+export const getAdminProfile = async () => {
+  const response = await getRequest<IGetAdminProfileResponse>("/admin/profile");
+  return response;
+};
+
+/* 어드민 접근 페이지 허용 여부 조회 */
+export const checkAdminAuthority = async () => {
+  const response = await getRequest("/admin/authority-check");
   return response;
 };

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -10,26 +10,31 @@ import {
 } from "../../types/admin";
 import { getRequest } from "../requests.api";
 
+/* 어드민 계정 목록 조회 */
 export const getAdminAccounts = async (page: number, size: number) => {
   const response = await getRequest<IGetAdminAccountsResponse>(`/admin?page=${page}&size=${size}`);
   return response;
 };
 
+/* 아티스트 계정 목록 조회 */
 export const getArtistAccounts = async (page: number, size: number) => {
   const response = await getRequest<IGetArtistAccountsResponse>(`/admin/artist?page=${page}&size=${size}`);
   return response;
 };
 
+/* 어드민 대시보드 카드 내용 */
 export const getAdminDashboardCards = async (month: string) => {
   const response = await getRequest<IGetAdminDashboardResponse>(`/admin/dashboard?monthly=${convertToYearMonthFormat(month)}`);
   return response;
 };
 
+/* 어드민 대시보드 도넛 차트 내용 */
 export const getAdminDashboardDoughnut = async (month: string, rank: number) => {
   const response = await getRequest<IGetAdminEarningsTopArtistResponse>(`/admin/dashboard/artist?monthly=${convertToYearMonthFormat(month)}&rank=${rank}`);
   return response;
 };
 
+/* 어드민 대시보드 테이블 내용 */
 export const getAdminDashboardTable = async (
   month: string,
   page: number,
@@ -44,6 +49,7 @@ export const getAdminDashboardTable = async (
   return response;
 };
 
+/* 어드민 대시보드 막대 차트 내용 */
 export const getAdminDashboardBar = async (startDate: string, endDate: string) => {
   const response = await getRequest<IGetAdminMonthlyEarningsTrendsResponse>(`/admin/dashboard/trend?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
   return response;

--- a/src/services/api/requests/admin/admin.patch.api.ts
+++ b/src/services/api/requests/admin/admin.patch.api.ts
@@ -1,11 +1,12 @@
 import { IPatchAdminProfileData, IPatchAdminProfileResponse } from "../../types/admin";
 import { patchRequest } from "../requests.api";
 
+/* 어드민의 본인 프로필 수정 */
 export const patchAdminProfile = async (
   patchData: IPatchAdminProfileData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string } = {};
+  const dataList: { [key: string]: string } = {};
 
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;

--- a/src/services/api/requests/admin/admin.patch.api.ts
+++ b/src/services/api/requests/admin/admin.patch.api.ts
@@ -5,12 +5,12 @@ export const patchAdminProfile = async (
   patchData: IPatchAdminProfileData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string } = {};
+  const dataList: { [key : string]: string | null } = {};
 
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;
     if (key === "file") {
-      formData.append("file", key);
+      formData.append("file", value ?? "");
     }
     dataList[key] = value;
   });

--- a/src/services/api/requests/admin/admin.patch.api.ts
+++ b/src/services/api/requests/admin/admin.patch.api.ts
@@ -1,0 +1,26 @@
+import { IPatchAdminProfileData, IPatchAdminProfileResponse } from "../../types/admin";
+import { patchRequest } from "../requests.api";
+
+export const patchAdminProfile = async (
+  patchData: IPatchAdminProfileData,
+) => {
+  const formData = new FormData();
+  const dataList: { [key : string]: string } = {};
+
+  Object.entries(patchData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", key);
+    }
+    dataList[key] = value;
+  });
+  formData.append("data", JSON.stringify(dataList));
+
+  const response = await patchRequest<IPatchAdminProfileResponse, FormData>("/admin/profile", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};

--- a/src/services/api/requests/admin/admin.patch.api.ts
+++ b/src/services/api/requests/admin/admin.patch.api.ts
@@ -5,14 +5,14 @@ export const patchAdminProfile = async (
   patchData: IPatchAdminProfileData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string | null } = {};
+  const dataList: { [key : string]: string } = {};
 
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;
     if (key === "file") {
-      formData.append("file", value ?? "");
+      formData.append("file", (value ?? ""));
     }
-    dataList[key] = value;
+    dataList[key] = value as string;
   });
   formData.append("data", JSON.stringify(dataList));
 

--- a/src/services/api/requests/albums/albums.delete.api.ts
+++ b/src/services/api/requests/albums/albums.delete.api.ts
@@ -1,0 +1,8 @@
+import { IDeleteAlbumResponse } from "../../types/albums";
+import { deleteRequest } from "../requests.api";
+
+/* 앨범 삭제 */
+export const deleteAlbum = async (albumId: number) => {
+  const response = await deleteRequest<IDeleteAlbumResponse>(`/albums/${albumId}`);
+  return response;
+};

--- a/src/services/api/requests/albums/albums.get.api.ts
+++ b/src/services/api/requests/albums/albums.get.api.ts
@@ -2,9 +2,9 @@ import convertYearMonthToQuery from "@/utils/convertYearMonthToQuery";
 
 import {
   IGetAlbumDashboardResponse,
-  IGetAlbumMonthlySettlementResponse,
+  IGetAlbumMonthlyTrendsResponse,
   IGetAlbumRevenueTopTrackResponse,
-  IGetAlbumTrackSettlementTrendsResponse,
+  IGetAlbumTracksTrendsResponse,
   IGetAlbumTracksResponse,
   IGetAlbumsResponse,
 } from "../../types/albums";
@@ -24,7 +24,7 @@ export const getAlbumTracks = async (albumId: number) => {
 
 /* 앨범의 월별 정산액 */
 export const getAlbumDashboardBar = async (albumId: number, startDate: string, endDate: string) => {
-  const response = getRequest<IGetAlbumMonthlySettlementResponse>(`/albums/${albumId}/dashboard?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
+  const response = getRequest<IGetAlbumMonthlyTrendsResponse>(`/albums/${albumId}/dashboard?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
   return response;
 };
 
@@ -42,6 +42,6 @@ export const getAlbumDashboardDoughnut = async (albumId: number, month: string, 
 
 /* 앨범의 트랙별 정산 리스트 */
 export const getAlbumDashboardLine = (albumId: number, startDate: string, endDate: string) => {
-  const response = getRequest<IGetAlbumTrackSettlementTrendsResponse>(`/albums/${albumId}/dashboard/track?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
+  const response = getRequest<IGetAlbumTracksTrendsResponse>(`/albums/${albumId}/dashboard/track?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
   return response;
 };

--- a/src/services/api/requests/albums/albums.get.api.ts
+++ b/src/services/api/requests/albums/albums.get.api.ts
@@ -36,7 +36,7 @@ export const getAlbumDashboardCards = async (albumId: number, month: string) => 
 
 /* 앨범의 당월 매출 Top N 트랙 리스트 정보 */
 export const getAlbumDashboardDoughnut = async (albumId: number, month: string, rank: number) => {
-  const response = getRequest<IGetAlbumRevenueTopTrackResponse>(`/albums/${albumId}/dashboard/topTrack?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
+  const response = getRequest<IGetAlbumRevenueTopTrackResponse>(`/albums/${albumId}/dashboard/top-track?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
   return response;
 };
 

--- a/src/services/api/requests/albums/albums.patch.api.ts
+++ b/src/services/api/requests/albums/albums.patch.api.ts
@@ -11,7 +11,7 @@ export const patchAlbum = async (
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;
     if (key === "file") {
-      formData.append("file", key);
+      formData.append("file", (value ?? "") as string);
     }
     dataList[key] = value;
   });

--- a/src/services/api/requests/albums/albums.patch.api.ts
+++ b/src/services/api/requests/albums/albums.patch.api.ts
@@ -11,9 +11,9 @@ export const patchAlbum = async (
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;
     if (key === "file") {
-      formData.append("file", (value ?? "") as string);
+      formData.append("file", (value ?? "") as File | string);
     }
-    dataList[key] = value;
+    dataList[key] = value as string | number | null;
   });
   formData.append("data", JSON.stringify(dataList));
 

--- a/src/services/api/requests/albums/albums.patch.api.ts
+++ b/src/services/api/requests/albums/albums.patch.api.ts
@@ -1,0 +1,27 @@
+import { IPatchAlbumData, IPatchAlbumResponse } from "../../types/albums";
+import { patchRequest } from "../requests.api";
+
+export const patchAlbum = async (
+  albumId: number,
+  patchData: IPatchAlbumData,
+) => {
+  const formData = new FormData();
+  const dataList: { [key : string]: string | number | null } = {};
+
+  Object.entries(patchData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", key);
+    }
+    dataList[key] = value;
+  });
+  formData.append("data", JSON.stringify(dataList));
+
+  const response = await patchRequest<IPatchAlbumResponse, FormData>(`/albums/${albumId}`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};

--- a/src/services/api/requests/albums/albums.patch.api.ts
+++ b/src/services/api/requests/albums/albums.patch.api.ts
@@ -1,12 +1,13 @@
 import { IPatchAlbumData, IPatchAlbumResponse } from "../../types/albums";
 import { patchRequest } from "../requests.api";
 
+/* 앨범 정보 수정 */
 export const patchAlbum = async (
   albumId: number,
   patchData: IPatchAlbumData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string | number | null } = {};
+  const dataList: { [key: string]: string | number | null } = {};
 
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;

--- a/src/services/api/requests/albums/albums.post.api.ts
+++ b/src/services/api/requests/albums/albums.post.api.ts
@@ -1,0 +1,26 @@
+import { IPostAlbumResponse } from "../../types/albums";
+import { postRequest } from "../requests.api";
+
+export const postAlbum = async (
+  name: string,
+  enName: string,
+  memberId: number | null,
+  file: File | null,
+) => {
+  const formData = new FormData();
+
+  formData.append("file", file ?? "");
+  formData.append("data", JSON.stringify({
+    name,
+    enName,
+    memberId, // null이 들어갈 때 정상 작동 확인 요망
+  }));
+
+  const response = await postRequest<IPostAlbumResponse, FormData>("/albums", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};

--- a/src/services/api/requests/albums/albums.post.api.ts
+++ b/src/services/api/requests/albums/albums.post.api.ts
@@ -1,20 +1,20 @@
-import { IPostAlbumResponse } from "../../types/albums";
+import { IPostAlbumData, IPostAlbumResponse } from "../../types/albums";
 import { postRequest } from "../requests.api";
 
 export const postAlbum = async (
-  name: string,
-  enName: string,
-  memberId: number | null,
-  file: File | null,
+  postData: IPostAlbumData,
 ) => {
   const formData = new FormData();
+  const dataList: { [key : string]: string | number | null } = {};
 
-  formData.append("file", file ?? "");
-  formData.append("data", JSON.stringify({
-    name,
-    enName,
-    memberId, // null이 들어갈 때 정상 작동 확인 요망
-  }));
+  Object.entries(postData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", (value ?? "") as File | string);
+    }
+    dataList[key] = value as string | number | null;
+  });
+  formData.append("data", JSON.stringify(dataList)); // memberId null 들어갈 때 정상 작동하는지 확인 요망
 
   const response = await postRequest<IPostAlbumResponse, FormData>("/albums", formData, {
     headers: {

--- a/src/services/api/requests/albums/albums.post.api.ts
+++ b/src/services/api/requests/albums/albums.post.api.ts
@@ -1,11 +1,12 @@
 import { IPostAlbumData, IPostAlbumResponse } from "../../types/albums";
 import { postRequest } from "../requests.api";
 
+/* 앨범 추가 */
 export const postAlbum = async (
   postData: IPostAlbumData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string | number | null } = {};
+  const dataList: { [key: string]: string | number | null } = {};
 
   Object.entries(postData).forEach((item) => {
     const [key, value] = item;

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -11,6 +11,7 @@ import {
 } from "../../types/artist";
 import { getRequest } from "../requests.api";
 
+/* 아티스트 현황 조회 */
 export const getArtistsStatus = async (
   month: string,
   page: number,
@@ -23,6 +24,7 @@ export const getArtistsStatus = async (
   return response;
 };
 
+/* 특정 아티스트의 앨범 목록(카드) 조회 */
 export const getArtistAlbums = async (
   page: number,
   size: number,
@@ -35,6 +37,7 @@ export const getArtistAlbums = async (
   return response;
 };
 
+/* 아티스트 대시보드 막대 차트 내용 */
 export const getArtistDashboardBar = async (
   startDate: string,
   endDate: string,
@@ -44,16 +47,19 @@ export const getArtistDashboardBar = async (
   return response;
 };
 
+/* 아티스트 대시보드 카드 내용 */
 export const getArtistDashboardCards = async (month: string, memberId: number) => {
   const response = await getRequest<IGetArtistDashboardResponse>(`/artists/${memberId}/dashboard/summary?monthly=${convertToYearMonthFormat(month)}`);
   return response;
 };
 
+/* 아티스트 대시보드 도넛 차트 내용 */
 export const getArtistDashboardDoughnut = async (month: string, rank: number, memberId: number) => {
   const response = await getRequest<IGetArtistEarningsTopTrackResponse>(`/artists/${memberId}/dashboard/topTrack?monthly=${convertToYearMonthFormat(month)}&rank=${rank}`);
   return response;
 };
 
+/* 아티스트 대시보드 테이블 내용 */
 export const getArtistDashboardTable = async (
   month: string,
   page: number,
@@ -69,6 +75,7 @@ export const getArtistDashboardTable = async (
   return response;
 };
 
+/* 드롭다운에 나타나는 아티스트 목록 조회 */
 export const getDropdownArtists = async () => {
   const response = await getRequest<IGetArtistsSimpleResponse>("/artists/simple");
   return response;

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -56,7 +56,7 @@ export const getArtistDashboardCards = async (month: string, memberId: number) =
 
 /* 아티스트 대시보드 도넛 차트 내용 */
 export const getArtistDashboardDoughnut = async (month: string, rank: number, memberId: number) => {
-  const response = await getRequest<IGetArtistEarningsTopTrackResponse>(`/artists/${memberId}/dashboard/topTrack?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
+  const response = await getRequest<IGetArtistEarningsTopTrackResponse>(`/artists/${memberId}/dashboard/top-track?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
   return response;
 };
 

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -1,4 +1,4 @@
-import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthPicker.util";
+import convertYearMonthToQuery from "@/utils/convertYearMonthToQuery";
 
 import {
   IGetArtistAlbumsResponse,
@@ -20,7 +20,7 @@ export const getArtistsStatus = async (
   keyword: string | null,
 ) => {
   const response = await getRequest<IGetArtistsResponse>(
-    `/artists?page=${page}&size=${size}&monthly=${convertToYearMonthFormat(month)}&keyword=${keyword ?? ""}`,
+    `/artists?page=${page}&size=${size}&monthly=${convertYearMonthToQuery(month)}&keyword=${keyword ?? ""}`,
   );
   return response;
 };
@@ -44,19 +44,19 @@ export const getArtistDashboardBar = async (
   endDate: string,
   memberId: number,
 ) => {
-  const response = await getRequest<IGetArtistMonthlyTrendsResponse>(`/artists/${memberId}/dashboard?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
+  const response = await getRequest<IGetArtistMonthlyTrendsResponse>(`/artists/${memberId}/dashboard?startDate=${convertYearMonthToQuery(startDate)}&endDate=${convertYearMonthToQuery(endDate)}`);
   return response;
 };
 
 /* 아티스트 대시보드 카드 내용 */
 export const getArtistDashboardCards = async (month: string, memberId: number) => {
-  const response = await getRequest<IGetArtistDashboardResponse>(`/artists/${memberId}/dashboard/summary?monthly=${convertToYearMonthFormat(month)}`);
+  const response = await getRequest<IGetArtistDashboardResponse>(`/artists/${memberId}/dashboard/summary?monthly=${convertYearMonthToQuery(month)}`);
   return response;
 };
 
 /* 아티스트 대시보드 도넛 차트 내용 */
 export const getArtistDashboardDoughnut = async (month: string, rank: number, memberId: number) => {
-  const response = await getRequest<IGetArtistEarningsTopTrackResponse>(`/artists/${memberId}/dashboard/topTrack?monthly=${convertToYearMonthFormat(month)}&rank=${rank}`);
+  const response = await getRequest<IGetArtistEarningsTopTrackResponse>(`/artists/${memberId}/dashboard/topTrack?monthly=${convertYearMonthToQuery(month)}&rank=${rank}`);
   return response;
 };
 
@@ -71,7 +71,7 @@ export const getArtistDashboardTable = async (
   memberId: number,
 ) => {
   const response = await getRequest<IGetArtistTrackTransactionResponse>(
-    `/artists/${memberId}/dashboard/track?monthly=${convertToYearMonthFormat(month)}&page=${page}&size=${size}&sortBy=${sortBy ?? ""}&searchBy=${searchBy}&keyword=${keyword ?? ""}`,
+    `/artists/${memberId}/dashboard/track?monthly=${convertYearMonthToQuery(month)}&page=${page}&size=${size}&sortBy=${sortBy ?? ""}&searchBy=${searchBy}&keyword=${keyword ?? ""}`,
   );
   return response;
 };

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -5,6 +5,7 @@ import {
   IGetArtistAlbumsResponse,
   IGetArtistDashboardResponse,
   IGetArtistEarningsTopTrackResponse,
+  IGetArtistProfileResponse,
   IGetArtistTrackTransactionResponse,
   IGetArtistsResponse,
   IGetArtistsSimpleResponse,
@@ -78,5 +79,11 @@ export const getArtistDashboardTable = async (
 /* 드롭다운에 나타나는 아티스트 목록 조회 */
 export const getDropdownArtists = async () => {
   const response = await getRequest<IGetArtistsSimpleResponse>("/artists/simple");
+  return response;
+};
+
+/* 아티스트 본인의 프로필 조회 */
+export const getArtistProfile = async () => {
+  const response = await getRequest<IGetArtistProfileResponse>("/artists/profile");
   return response;
 };

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -1,10 +1,10 @@
 import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthPicker.util";
 
-import { IGetArtistMonthlyEarningsTrendsResponse } from "../../types/admin";
 import {
   IGetArtistAlbumsResponse,
   IGetArtistDashboardResponse,
   IGetArtistEarningsTopTrackResponse,
+  IGetArtistMonthlyTrendsResponse,
   IGetArtistProfileResponse,
   IGetArtistTrackTransactionResponse,
   IGetArtistsResponse,
@@ -44,7 +44,7 @@ export const getArtistDashboardBar = async (
   endDate: string,
   memberId: number,
 ) => {
-  const response = await getRequest<IGetArtistMonthlyEarningsTrendsResponse>(`/artists/${memberId}/dashboard?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
+  const response = await getRequest<IGetArtistMonthlyTrendsResponse>(`/artists/${memberId}/dashboard?startDate=${convertToYearMonthFormat(startDate)}&endDate=${convertToYearMonthFormat(endDate)}`);
   return response;
 };
 

--- a/src/services/api/requests/artist/artist.patch.api.ts
+++ b/src/services/api/requests/artist/artist.patch.api.ts
@@ -1,4 +1,9 @@
-import { IPatchArtistProfileForAdminRequest, IPatchArtistProfileForAdminResponse } from "../../types/artist";
+import {
+  IPatchArtistProfileData,
+  IPatchArtistProfileForAdminRequest,
+  IPatchArtistProfileForAdminResponse,
+  IPatchArtistProfileResponse,
+} from "../../types/artist";
 import { patchRequest } from "../requests.api";
 
 /* admin이 아티스트 프로필을 수정하는 api */
@@ -7,6 +12,30 @@ export const patchArtistProfileForAdmin = async (
   patchData: IPatchArtistProfileForAdminRequest,
 ) => {
   const response = await patchRequest<IPatchArtistProfileForAdminResponse, IPatchArtistProfileForAdminRequest>(`artists/${memberId}/profile`, patchData, {
+  });
+
+  return response;
+};
+
+export const patchArtistProfile = async (
+  patchData: IPatchArtistProfileData,
+) => {
+  const formData = new FormData();
+  const dataList: { [key : string]: string } = {};
+
+  Object.entries(patchData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", value ?? "");
+    }
+    dataList[key] = value as string;
+  });
+  formData.append("data", JSON.stringify(dataList));
+
+  const response = await patchRequest<IPatchArtistProfileResponse, FormData>("/artist/profile", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
   });
 
   return response;

--- a/src/services/api/requests/artist/artist.patch.api.ts
+++ b/src/services/api/requests/artist/artist.patch.api.ts
@@ -6,7 +6,7 @@ import {
 } from "../../types/artist";
 import { patchRequest } from "../requests.api";
 
-/* admin이 아티스트 프로필을 수정하는 api */
+/* 어드민이 아티스트 프로필을 수정 */
 export const patchArtistProfileForAdmin = async (
   memberId: number,
   patchData: IPatchArtistProfileForAdminRequest,
@@ -17,11 +17,12 @@ export const patchArtistProfileForAdmin = async (
   return response;
 };
 
+/* 아티스트의 본인 프로필 수정 */
 export const patchArtistProfile = async (
   patchData: IPatchArtistProfileData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string } = {};
+  const dataList: { [key: string]: string } = {};
 
   Object.entries(patchData).forEach((item) => {
     const [key, value] = item;

--- a/src/services/api/requests/artist/artist.patch.api.ts
+++ b/src/services/api/requests/artist/artist.patch.api.ts
@@ -1,0 +1,13 @@
+import { IPatchArtistProfileForAdminRequest, IPatchArtistProfileForAdminResponse } from "../../types/artist";
+import { patchRequest } from "../requests.api";
+
+/* admin이 아티스트 프로필을 수정하는 api */
+export const patchArtistProfileForAdmin = async (
+  memberId: number,
+  patchData: IPatchArtistProfileForAdminRequest,
+) => {
+  const response = await patchRequest<IPatchArtistProfileForAdminResponse, IPatchArtistProfileForAdminRequest>(`artists/${memberId}/profile`, patchData, {
+  });
+
+  return response;
+};

--- a/src/services/api/requests/artist/artist.post.api.ts
+++ b/src/services/api/requests/artist/artist.post.api.ts
@@ -1,11 +1,12 @@
 import { IPostArtistData, IPostArtistResponse } from "../../types/artist";
 import { postRequest } from "../requests.api";
 
+/* 아티스트 생성 */
 export const postArtist = async (
   postData: IPostArtistData,
 ) => {
   const formData = new FormData();
-  const dataList: { [key : string]: string | number | null } = {};
+  const dataList: { [key: string]: string | number | null } = {};
 
   Object.entries(postData).forEach((item) => {
     const [key, value] = item;

--- a/src/services/api/requests/artist/artist.post.api.ts
+++ b/src/services/api/requests/artist/artist.post.api.ts
@@ -1,26 +1,20 @@
-import { IPostArtistResponse } from "../../types/artist";
+import { IPostArtistData, IPostArtistResponse } from "../../types/artist";
 import { postRequest } from "../requests.api";
 
 export const postArtist = async (
-  file: File | null,
-  email: string,
-  loginId: string,
-  name: string,
-  enName: string,
-  password: string,
-  commissionRate: number | null,
+  postData: IPostArtistData,
 ) => {
   const formData = new FormData();
+  const dataList: { [key : string]: string | number | null } = {};
 
-  formData.append("file", file ?? "");
-  formData.append("data", JSON.stringify({
-    email,
-    loginId,
-    name,
-    enName,
-    password,
-    commissionRate, // null이 들어갈 때 정상 작동 확인 요망
-  }));
+  Object.entries(postData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", (value ?? "") as File | string);
+    }
+    dataList[key] = value as string | number | null;
+  });
+  formData.append("data", JSON.stringify(dataList)); // commissionRate null 들어갈 때 정상 작동하는지 확인 요망
 
   const response = await postRequest<IPostArtistResponse, FormData>("/artists", formData, {
     headers: {

--- a/src/services/api/requests/artist/artist.post.api.ts
+++ b/src/services/api/requests/artist/artist.post.api.ts
@@ -1,0 +1,32 @@
+import { IPostArtistResponse } from "../../types/artist";
+import { postRequest } from "../requests.api";
+
+export const postArtist = async (
+  file: File | null,
+  email: string,
+  loginId: string,
+  name: string,
+  enName: string,
+  password: string,
+  commissionRate: number | null,
+) => {
+  const formData = new FormData();
+
+  formData.append("file", file ?? "");
+  formData.append("data", JSON.stringify({
+    email,
+    loginId,
+    name,
+    enName,
+    password,
+    commissionRate, // null이 들어갈 때 정상 작동 확인 요망
+  }));
+
+  const response = await postRequest<IPostArtistResponse, FormData>("/artists", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};

--- a/src/services/api/requests/auth/auth.delete.api.ts
+++ b/src/services/api/requests/auth/auth.delete.api.ts
@@ -1,5 +1,6 @@
 import { deleteRequest } from "../requests.api";
 
+/* 계정 탈퇴 */
 export const withdrawMember = async (memberId: number) => {
   const response = await deleteRequest<string>(`/auth/members/${memberId}/withdrawal`);
   return response;

--- a/src/services/api/requests/auth/auth.patch.api.ts
+++ b/src/services/api/requests/auth/auth.patch.api.ts
@@ -1,6 +1,7 @@
 import { IPatchChangePasswordRequest } from "../../types/auth";
 import { postRequest } from "../requests.api";
 
+/* 비밀번호 변경 */
 export const changePassword = async ({
   password,
 }: IPatchChangePasswordRequest) => {

--- a/src/services/api/requests/auth/auth.post.api.ts
+++ b/src/services/api/requests/auth/auth.post.api.ts
@@ -10,6 +10,7 @@ import {
 import { postRequest } from "../requests.api";
 
 /**
+ * 어드민 로그인
  * 로그인 후 TODO
  * ```
  * const data = await signIn(
@@ -36,6 +37,7 @@ export const adminSignIn = async (
   return response;
 };
 
+/* 아티스트 로그인 */
 export const artistSignIn = async ({
   loginId,
   password,
@@ -47,6 +49,7 @@ export const artistSignIn = async ({
   return response;
 };
 
+/* 어드민 회원가입 */
 export const adminSignUp = async ({
   email,
   loginId,
@@ -62,6 +65,7 @@ export const adminSignUp = async ({
   return response;
 };
 
+/* 비밀번호 2차 검증 */
 export const confirmPassword = async ({
   password,
 }: IPostConfirmPasswordRequest) => {

--- a/src/services/api/requests/tracks/tracks.delete.api.ts
+++ b/src/services/api/requests/tracks/tracks.delete.api.ts
@@ -1,0 +1,8 @@
+import { IDeleteTrackResponse } from "../../types/tracks";
+import { deleteRequest } from "../requests.api";
+
+/* 트랙 삭제 */
+export const deleteTrack = async (trackId: number) => {
+  const response = deleteRequest<IDeleteTrackResponse>(`tracks/${trackId}`);
+  return response;
+};

--- a/src/services/api/requests/tracks/tracks.patch.api.ts
+++ b/src/services/api/requests/tracks/tracks.patch.api.ts
@@ -1,21 +1,14 @@
-import { ITrackParticipantInfo } from "@/types/dto";
-
-import { IPatchTrackData, IPatchTrackResponse } from "../../types/tracks";
+import { IPatchTrackRequest, IPatchTrackResponse } from "../../types/tracks";
 import { patchRequest } from "../requests.api";
 
 /* 앨범의 트랙 정보 변경 */
 export const patchTrack = async (
   trackId: number,
-  trackKoName: string,
-  trackEnName: string,
-  isOriginalTrack: boolean,
-  artists: ITrackParticipantInfo[],
+  patchData: IPatchTrackRequest,
 ) => {
-  const response = patchRequest<IPatchTrackResponse, IPatchTrackData>(`tracks/albums/${trackId}`, {
-    name: trackKoName,
-    enName: trackEnName,
-    isOriginalTrack,
-    artists,
-  });
+  const response = patchRequest<IPatchTrackResponse, IPatchTrackRequest>(
+    `tracks/albums/${trackId}`,
+    patchData,
+  );
   return response;
 };

--- a/src/services/api/requests/tracks/tracks.patch.api.ts
+++ b/src/services/api/requests/tracks/tracks.patch.api.ts
@@ -1,0 +1,21 @@
+import { ITrackParticipantInfo } from "@/types/dto";
+
+import { IPatchTrackData, IPatchTrackResponse } from "../../types/tracks";
+import { patchRequest } from "../requests.api";
+
+/* 앨범의 트랙 정보 변경 */
+export const patchTrack = async (
+  trackId: number,
+  trackKoName: string,
+  trackEnName: string,
+  isOriginalTrack: boolean,
+  artists: ITrackParticipantInfo[],
+) => {
+  const response = patchRequest<IPatchTrackResponse, IPatchTrackData>(`tracks/albums/${trackId}`, {
+    name: trackKoName,
+    enName: trackEnName,
+    isOriginalTrack,
+    artists,
+  });
+  return response;
+};

--- a/src/services/api/requests/tracks/tracks.post.api.ts
+++ b/src/services/api/requests/tracks/tracks.post.api.ts
@@ -1,0 +1,21 @@
+import { ITrackParticipantInfo } from "@/types/dto";
+
+import { IPostTrackData, IPostTrackResponse } from "../../types/tracks";
+import { postRequest } from "../requests.api";
+
+/* 앨범의 트랙 등록 */
+export const postTrack = async (
+  albumId: number,
+  trackKoName: string,
+  trackEnName: string,
+  isOriginalTrack: boolean,
+  artists: ITrackParticipantInfo[],
+) => {
+  const response = postRequest<IPostTrackResponse, IPostTrackData>(`albums/${albumId}`, {
+    name: trackKoName,
+    enName: trackEnName,
+    isOriginalTrack,
+    artists,
+  });
+  return response;
+};

--- a/src/services/api/requests/tracks/tracks.post.api.ts
+++ b/src/services/api/requests/tracks/tracks.post.api.ts
@@ -1,19 +1,16 @@
-import { ITrackParticipantInfo } from "@/types/dto";
-
-import { IPostTrackData, IPostTrackResponse } from "../../types/tracks";
+import { IPostTrackRequest, IPostTrackResponse } from "../../types/tracks";
 import { postRequest } from "../requests.api";
 
 /* 앨범의 트랙 등록 */
 export const postTrack = async (
   albumId: number,
-  trackKoName: string,
-  trackEnName: string,
-  isOriginalTrack: boolean,
-  artists: ITrackParticipantInfo[],
+  {
+    name, enName, isOriginalTrack, artists,
+  }: IPostTrackRequest,
 ) => {
-  const response = postRequest<IPostTrackResponse, IPostTrackData>(`albums/${albumId}`, {
-    name: trackKoName,
-    enName: trackEnName,
+  const response = postRequest<IPostTrackResponse, IPostTrackRequest>(`albums/${albumId}`, {
+    name,
+    enName,
     isOriginalTrack,
     artists,
   });

--- a/src/services/api/requests/transaction/transaction.delete.api.ts
+++ b/src/services/api/requests/transaction/transaction.delete.api.ts
@@ -1,0 +1,8 @@
+import { IDeleteTransactionUploadResponse } from "../../types/transaction";
+import { deleteRequest } from "../requests.api";
+
+/* 엑셀 파일 업로드 History 삭제 API */
+export const deleteUploadHistory = async (fileId: number) => {
+  const response = await deleteRequest<IDeleteTransactionUploadResponse>(`transactions/${fileId}`);
+  return response;
+};

--- a/src/services/api/requests/transaction/transaction.get.api.ts
+++ b/src/services/api/requests/transaction/transaction.get.api.ts
@@ -3,6 +3,7 @@ import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthP
 import { IGetTransactionUploadResponse } from "../../types/transaction";
 import { getRequest } from "../requests.api";
 
+/* 엑셀 파일 업로드 History 조회 */
 export const getUploadHistory = async (month: string) => {
   const response = await getRequest<IGetTransactionUploadResponse>(`/transactions?monthly=${convertToYearMonthFormat(month)}`);
   return response;

--- a/src/services/api/requests/transaction/transaction.get.api.ts
+++ b/src/services/api/requests/transaction/transaction.get.api.ts
@@ -1,10 +1,10 @@
-import { convertToYearMonthFormat } from "@/components/common/MonthPicker/MonthPicker.util";
+import convertYearMonthToQuery from "@/utils/convertYearMonthToQuery";
 
 import { IGetTransactionUploadResponse } from "../../types/transaction";
 import { getRequest } from "../requests.api";
 
 /* 엑셀 파일 업로드 History 조회 */
 export const getUploadHistory = async (month: string) => {
-  const response = await getRequest<IGetTransactionUploadResponse>(`/transactions?monthly=${convertToYearMonthFormat(month)}`);
+  const response = await getRequest<IGetTransactionUploadResponse>(`/transactions?monthly=${convertYearMonthToQuery(month)}`);
   return response;
 };

--- a/src/services/api/requests/transaction/transaction.post.api.ts
+++ b/src/services/api/requests/transaction/transaction.post.api.ts
@@ -1,0 +1,16 @@
+import { postRequest } from "../requests.api";
+
+/* 엑셀 파일 업로드 API */
+export const uploadTransaction = async (file: File, uploadAt: string) => {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("data", JSON.stringify({ uploadAt }));
+
+  const response = await postRequest("/transactions", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response;
+};

--- a/src/services/api/requests/transaction/transaction.post.api.ts
+++ b/src/services/api/requests/transaction/transaction.post.api.ts
@@ -1,11 +1,19 @@
-import { IPostTransactionUploadResponse } from "../../types/transaction";
+import { IPostTransactionUploadData, IPostTransactionUploadResponse } from "../../types/transaction";
 import { postRequest } from "../requests.api";
 
 /* 엑셀 파일 업로드 API */
-export const uploadTransaction = async (file: File, uploadAt: string) => {
+export const uploadTransaction = async (postData: IPostTransactionUploadData) => {
   const formData = new FormData();
-  formData.append("file", file);
-  formData.append("data", JSON.stringify({ uploadAt }));
+  const dataList: { [key : string]: string } = {};
+
+  Object.entries(postData).forEach((item) => {
+    const [key, value] = item;
+    if (key === "file") {
+      formData.append("file", value as File);
+    }
+    dataList[key] = value as string;
+  });
+  formData.append("data", JSON.stringify(dataList));
 
   const response = await postRequest<IPostTransactionUploadResponse, FormData>("/transactions", formData, {
     headers: {

--- a/src/services/api/requests/transaction/transaction.post.api.ts
+++ b/src/services/api/requests/transaction/transaction.post.api.ts
@@ -1,3 +1,4 @@
+import { IPostTransactionUploadResponse } from "../../types/transaction";
 import { postRequest } from "../requests.api";
 
 /* 엑셀 파일 업로드 API */
@@ -6,7 +7,7 @@ export const uploadTransaction = async (file: File, uploadAt: string) => {
   formData.append("file", file);
   formData.append("data", JSON.stringify({ uploadAt }));
 
-  const response = await postRequest("/transactions", formData, {
+  const response = await postRequest<IPostTransactionUploadResponse, FormData>("/transactions", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },

--- a/src/services/api/types/admin.ts
+++ b/src/services/api/types/admin.ts
@@ -42,7 +42,7 @@ export interface IGetArtistAccountsResponse {
 }
 
 export type IPatchAdminProfileData = AtLeastOne<{
-  file: string,
+  file: string | null,
   nickname: string,
   email: string,
 }>;

--- a/src/services/api/types/admin.ts
+++ b/src/services/api/types/admin.ts
@@ -49,3 +49,6 @@ export type IPatchAdminProfileData = AtLeastOne<{
 
 export interface IPatchAdminProfileResponse extends Omit<IAdminProfile, "type"> {
 }
+
+export interface IGetAdminProfileResponse extends Omit<IAdminProfile, "type"> {
+}

--- a/src/services/api/types/admin.ts
+++ b/src/services/api/types/admin.ts
@@ -3,7 +3,6 @@ import {
   IBarMonthlyEarnings,
   IDoughnutArtistRevenue,
   ITrackTransaction,
-  IBarMonthlySettlement,
   IAdminAccount,
   IArtistAccount,
   IAdminProfile,
@@ -14,12 +13,8 @@ import { AtLeastOne } from "./global";
 export interface IGetAdminDashboardResponse extends IAdminDashboardCard {
 }
 
-export interface IGetAdminMonthlyEarningsTrendsResponse {
+export interface IGetAdminMonthlyTrendsResponse {
   contents: IBarMonthlyEarnings[]
-}
-
-export interface IGetArtistMonthlyEarningsTrendsResponse {
-  contents: IBarMonthlySettlement[]
 }
 
 export interface IGetAdminTrackTransactionResponse {

--- a/src/services/api/types/admin.ts
+++ b/src/services/api/types/admin.ts
@@ -42,7 +42,7 @@ export interface IGetArtistAccountsResponse {
 }
 
 export type IPatchAdminProfileData = AtLeastOne<{
-  file: string | null,
+  file: File | null,
   nickname: string,
   email: string,
 }>;

--- a/src/services/api/types/admin.ts
+++ b/src/services/api/types/admin.ts
@@ -6,7 +6,10 @@ import {
   IBarMonthlySettlement,
   IAdminAccount,
   IArtistAccount,
+  IAdminProfile,
 } from "@/types/dto";
+
+import { AtLeastOne } from "./global";
 
 export interface IGetAdminDashboardResponse extends IAdminDashboardCard {
 }
@@ -36,4 +39,13 @@ export interface IGetAdminAccountsResponse {
 export interface IGetArtistAccountsResponse {
   totalItems: number,
   contents: IArtistAccount[]
+}
+
+export type IPatchAdminProfileData = AtLeastOne<{
+  file: string,
+  nickname: string,
+  email: string,
+}>;
+
+export interface IPatchAdminProfileResponse extends Omit<IAdminProfile, "type"> {
 }

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -29,3 +29,6 @@ export interface IGetAlbumTrackSettlementTrendsResponse {
 export interface IGetAlbumRevenueTopTrackResponse {
   contents: IDoughnutTrackRevenue[]
 }
+
+export interface IPostAlbumResponse extends IAlbumCard {
+}

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -39,7 +39,7 @@ export interface IDeleteAlbumResponse extends IAlbumCard {
 }
 
 export type IPatchAlbumData = AtLeastOne<{
-  file: string,
+  file: string | null,
   name: string,
   enName: string,
   memberId: number | null

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -7,6 +7,8 @@ import {
   ILineTrackSettlementTrends,
 } from "@/types/dto";
 
+import { AtLeastOne } from "./global";
+
 export interface IGetAlbumsResponse {
   totalItems: number,
   contents: IAlbumCard[]
@@ -34,4 +36,14 @@ export interface IPostAlbumResponse extends IAlbumCard {
 }
 
 export interface IDeleteAlbumResponse extends IAlbumCard {
+}
+
+export type IPatchAlbumData = AtLeastOne<{
+  file: string,
+  name: string,
+  enName: string,
+  memberId: number | null
+}>;
+
+export interface IPatchAlbumResponse extends IAlbumCard {
 }

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -32,3 +32,6 @@ export interface IGetAlbumRevenueTopTrackResponse {
 
 export interface IPostAlbumResponse extends IAlbumCard {
 }
+
+export interface IDeleteAlbumResponse extends IAlbumCard {
+}

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -20,11 +20,11 @@ export interface IGetAlbumDashboardResponse extends IAlbumDashboardCard {
 export interface IGetAlbumTracksResponse extends IAlbumInfo {
 }
 
-export interface IGetAlbumMonthlySettlementResponse {
+export interface IGetAlbumMonthlyTrendsResponse {
   contents: IBarMonthlySettlement[]
 }
 
-export interface IGetAlbumTrackSettlementTrendsResponse {
+export interface IGetAlbumTracksTrendsResponse {
   tracks: ILineTrackSettlementTrends[]
 }
 

--- a/src/services/api/types/albums.ts
+++ b/src/services/api/types/albums.ts
@@ -32,6 +32,13 @@ export interface IGetAlbumRevenueTopTrackResponse {
   contents: IDoughnutTrackRevenue[]
 }
 
+export type IPostAlbumData = {
+  file: File | null,
+  name: string,
+  enName: string,
+  memberId: number | null,
+};
+
 export interface IPostAlbumResponse extends IAlbumCard {
 }
 
@@ -39,7 +46,7 @@ export interface IDeleteAlbumResponse extends IAlbumCard {
 }
 
 export type IPatchAlbumData = AtLeastOne<{
-  file: string | null,
+  file: File | null,
   name: string,
   enName: string,
   memberId: number | null

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -1,12 +1,15 @@
 import {
   IAlbumCard,
   IArtist,
+  IArtistAccount,
   IArtistDashboardCard,
   IArtistList,
   IBarMonthlySettlement,
   IDoughnutTrackRevenue,
   ITrackTransaction,
 } from "@/types/dto";
+
+import { AtLeastOne } from "./global";
 
 export interface IGetArtistsResponse {
   totalItems: number,
@@ -50,3 +53,12 @@ export interface IGetArtistProfileResponse {
 export interface IPostArtistResponse extends IGetArtistProfileResponse {
   commissionRate: number | null
 }
+
+export interface IPatchArtistProfileForAdminResponse extends IArtistAccount {
+}
+
+export type IPatchArtistProfileForAdminRequest = AtLeastOne<{
+  name: string,
+  enName: string,
+  commissionRate: number | null,
+}>;

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -37,3 +37,16 @@ export interface IGetArtistAlbumsResponse {
 export interface IGetArtistsSimpleResponse {
   artists: IArtist[]
 }
+
+export interface IGetArtistProfileResponse {
+  memberId: number,
+  name: string,
+  enName: string,
+  loginId: string,
+  email: string,
+  profileImage: string
+}
+
+export interface IPostArtistResponse extends IGetArtistProfileResponse {
+  commissionRate: number | null
+}

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -29,7 +29,7 @@ export interface IGetArtistEarningsTopTrackResponse {
   contents: IDoughnutTrackRevenue[]
 }
 
-export interface IGetArtistMonthlySettlementResponse {
+export interface IGetArtistMonthlyTrendsResponse {
   contents: IBarMonthlySettlement[]
 }
 

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -42,15 +42,6 @@ export interface IGetArtistsSimpleResponse {
   artists: IArtist[]
 }
 
-export interface IGetArtistProfileResponse {
-  memberId: number,
-  name: string,
-  enName: string,
-  loginId: string,
-  email: string,
-  profileImage: string
-}
-
 export type IPostArtistData = {
   file: File | null,
   email: string,
@@ -80,4 +71,7 @@ export type IPatchArtistProfileData = AtLeastOne<{
 }>;
 
 export interface IPatchArtistProfileResponse extends Omit<IArtistProfile, "type"> {
+}
+
+export interface IGetArtistProfileResponse extends Omit<IArtistProfile, "type"> {
 }

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -38,8 +38,11 @@ export interface IGetArtistAlbumsResponse {
   contents: IAlbumCard[]
 }
 
+interface IDropdownArtist extends IArtist {
+  commissionRate: number | null
+}
 export interface IGetArtistsSimpleResponse {
-  artists: IArtist[]
+  artists: IDropdownArtist[]
 }
 
 export type IPostArtistData = {

--- a/src/services/api/types/artist.ts
+++ b/src/services/api/types/artist.ts
@@ -4,6 +4,7 @@ import {
   IArtistAccount,
   IArtistDashboardCard,
   IArtistList,
+  IArtistProfile,
   IBarMonthlySettlement,
   IDoughnutTrackRevenue,
   ITrackTransaction,
@@ -50,6 +51,16 @@ export interface IGetArtistProfileResponse {
   profileImage: string
 }
 
+export type IPostArtistData = {
+  file: File | null,
+  email: string,
+  loginId: string,
+  name: string,
+  enName: string,
+  password: string,
+  commissionRate: number | null,
+};
+
 export interface IPostArtistResponse extends IGetArtistProfileResponse {
   commissionRate: number | null
 }
@@ -62,3 +73,11 @@ export type IPatchArtistProfileForAdminRequest = AtLeastOne<{
   enName: string,
   commissionRate: number | null,
 }>;
+
+export type IPatchArtistProfileData = AtLeastOne<{
+  file: File | null,
+  email: string,
+}>;
+
+export interface IPatchArtistProfileResponse extends Omit<IArtistProfile, "type"> {
+}

--- a/src/services/api/types/global.ts
+++ b/src/services/api/types/global.ts
@@ -1,0 +1,1 @@
+export type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];

--- a/src/services/api/types/tracks.ts
+++ b/src/services/api/types/tracks.ts
@@ -1,5 +1,7 @@
 import { ITrackInfo, ITrackParticipantInfo } from "@/types/dto";
 
+import { AtLeastOne } from "./global";
+
 export interface IDeleteTrackResponse {
   trackId: number,
 }
@@ -8,7 +10,7 @@ export interface IPostTrackResponse extends ITrackInfo {
   albumId: number,
 }
 
-export interface IPostTrackData {
+export interface IPostTrackRequest {
   name: string,
   enName: string,
   isOriginalTrack: boolean,
@@ -18,5 +20,4 @@ export interface IPostTrackData {
 export interface IPatchTrackResponse extends IPostTrackResponse {
 }
 
-export interface IPatchTrackData extends IPostTrackData {
-}
+export type IPatchTrackRequest = AtLeastOne<IPostTrackRequest>;

--- a/src/services/api/types/tracks.ts
+++ b/src/services/api/types/tracks.ts
@@ -1,3 +1,16 @@
+import { ITrackInfo, ITrackParticipantInfo } from "@/types/dto";
+
 export interface IDeleteTrackResponse {
   trackId: number,
+}
+
+export interface IPostTrackResponse extends ITrackInfo {
+  albumId: number,
+}
+
+export interface IPostTrackData {
+  name: string,
+  enName: string,
+  isOriginalTrack: boolean,
+  artists: ITrackParticipantInfo[],
 }

--- a/src/services/api/types/tracks.ts
+++ b/src/services/api/types/tracks.ts
@@ -1,0 +1,3 @@
+export interface IDeleteTrackResponse {
+  trackId: number,
+}

--- a/src/services/api/types/tracks.ts
+++ b/src/services/api/types/tracks.ts
@@ -14,3 +14,9 @@ export interface IPostTrackData {
   isOriginalTrack: boolean,
   artists: ITrackParticipantInfo[],
 }
+
+export interface IPatchTrackResponse extends IPostTrackResponse {
+}
+
+export interface IPatchTrackData extends IPostTrackData {
+}

--- a/src/services/api/types/transaction.ts
+++ b/src/services/api/types/transaction.ts
@@ -5,6 +5,11 @@ export interface IGetTransactionUploadResponse {
   contents: ITransactionUpload[]
 }
 
+export type IPostTransactionUploadData = {
+  file: File,
+  uploadAt: string,
+};
+
 export interface IPostTransactionUploadResponse extends ITransactionUpload {
 }
 

--- a/src/services/api/types/transaction.ts
+++ b/src/services/api/types/transaction.ts
@@ -2,5 +2,8 @@ import { ITransactionUpload } from "@/types/dto";
 
 export interface IGetTransactionUploadResponse {
   totalItems: number,
-  contents: ITransactionUpload[] // 스웨거는 배열 형태
+  contents: ITransactionUpload[]
+}
+
+export interface IPostTransactionUploadResponse extends ITransactionUpload {
 }

--- a/src/services/api/types/transaction.ts
+++ b/src/services/api/types/transaction.ts
@@ -7,3 +7,6 @@ export interface IGetTransactionUploadResponse {
 
 export interface IPostTransactionUploadResponse extends ITransactionUpload {
 }
+
+export interface IDeleteTransactionUploadResponse extends ITransactionUpload {
+}

--- a/src/services/queries/dashboard/queryFns/albumTrendsChart.ts
+++ b/src/services/queries/dashboard/queryFns/albumTrendsChart.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
 import { MOCK_ALBUM_LINE } from "@/constants/mock";
-import { IGetAlbumTrackSettlementTrendsResponse } from "@/services/api/types/albums";
+import { IGetAlbumTracksTrendsResponse } from "@/services/api/types/albums";
 
-export const getMemberAlbumTrendsChart = (month: string, albumId: string): Promise<IGetAlbumTrackSettlementTrendsResponse> => {
+export const getMemberAlbumTrendsChart = (month: string, albumId: string): Promise<IGetAlbumTracksTrendsResponse> => {
   return new Promise((resolve) => {
     setTimeout(() => { return resolve(MOCK_ALBUM_LINE); }, 2000);
   });

--- a/src/services/queries/dashboard/queryFns/cards.ts
+++ b/src/services/queries/dashboard/queryFns/cards.ts
@@ -76,7 +76,7 @@ export const getDashboardCards = async (
     }];
   } else if (type === DASHBOARD_TYPE.ARTIST) {
     response = await getArtistDashboardCards(month, artistId);
-    const { bestAlbum, bestTrack, settlement } = response;
+    const { bestAlbum, bestTrack, settlementAmount: settlement } = response;
     data = [{
       title: "당월 정산액",
       content: formatMoney(settlement.totalAmount, "card"),
@@ -94,7 +94,7 @@ export const getDashboardCards = async (
     }];
   } else {
     response = await getAlbumDashboardCards(month, albumId);
-    const { settlement, bestTrack } = response;
+    const { settlementAmount: settlement, bestTrack } = response;
     data = [{
       title: "이 앨범의 당월 정산액",
       content: formatMoney(settlement.totalAmount, "card"),

--- a/src/services/queries/dashboard/queryFns/cards.ts
+++ b/src/services/queries/dashboard/queryFns/cards.ts
@@ -71,7 +71,7 @@ export const getDashboardCards = async (
     },
     {
       title: `${formattedMonth}의 아티스트`,
-      content: bestArtist.koArtistName,
+      content: bestArtist.name,
       growthRate: bestArtist.growthRate,
     }];
   } else if (type === DASHBOARD_TYPE.ARTIST) {
@@ -84,12 +84,12 @@ export const getDashboardCards = async (
     },
     {
       title: `${formattedMonth}의 앨범`,
-      content: bestAlbum.koAlbumName,
+      content: bestAlbum.name,
       growthRate: bestAlbum.growthRate,
     },
     {
       title: `${formattedMonth}의 트랙`,
-      content: bestTrack.koTrackName,
+      content: bestTrack.name,
       growthRate: bestTrack.growthRate,
     }];
   } else {
@@ -102,7 +102,7 @@ export const getDashboardCards = async (
     },
     {
       title: `${formattedMonth}의 트랙`,
-      content: bestTrack.koTrackName,
+      content: bestTrack.name,
       growthRate: bestTrack.growthRate,
     }];
   }

--- a/src/services/queries/dashboard/queryFns/trendsChart.ts
+++ b/src/services/queries/dashboard/queryFns/trendsChart.ts
@@ -1,13 +1,14 @@
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { MOCK_ADMIN_BAR, MOCK_ALBUM_BAR, MOCK_ARTIST_BAR } from "@/constants/mock";
-import { IGetAdminMonthlyEarningsTrendsResponse, IGetArtistMonthlyEarningsTrendsResponse } from "@/services/api/types/admin";
-import { IGetAlbumMonthlySettlementResponse } from "@/services/api/types/albums";
+import { IGetAdminMonthlyTrendsResponse } from "@/services/api/types/admin";
+import { IGetAlbumMonthlyTrendsResponse } from "@/services/api/types/albums";
+import { IGetArtistMonthlyTrendsResponse } from "@/services/api/types/artist";
 import { DASHBOARD_TYPE, DashboardType } from "@/types/enums/dashboard.enum";
 
-type DashBoardTrendsChart = IGetAdminMonthlyEarningsTrendsResponse | IGetArtistMonthlyEarningsTrendsResponse | IGetAlbumMonthlySettlementResponse;
+type DashBoardTrendsChart = IGetAdminMonthlyTrendsResponse | IGetArtistMonthlyTrendsResponse | IGetAlbumMonthlyTrendsResponse;
 
-const getAdminDashboardTrendsChart = (month: string): Promise<IGetAdminMonthlyEarningsTrendsResponse> => {
+const getAdminDashboardTrendsChart = (month: string): Promise<IGetAdminMonthlyTrendsResponse> => {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(MOCK_ADMIN_BAR);
@@ -15,7 +16,7 @@ const getAdminDashboardTrendsChart = (month: string): Promise<IGetAdminMonthlyEa
   });
 };
 
-const getArtistDashboardTrendsChart = (month: string, artistId?: string): Promise<IGetArtistMonthlyEarningsTrendsResponse> => {
+const getArtistDashboardTrendsChart = (month: string, artistId?: string): Promise<IGetArtistMonthlyTrendsResponse> => {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(MOCK_ARTIST_BAR);
@@ -23,7 +24,7 @@ const getArtistDashboardTrendsChart = (month: string, artistId?: string): Promis
   });
 };
 
-const getAlbumDashboardTrendsChart = (month: string, albumId?: string): Promise<IGetAlbumMonthlySettlementResponse> => {
+const getAlbumDashboardTrendsChart = (month: string, albumId?: string): Promise<IGetAlbumMonthlyTrendsResponse> => {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(MOCK_ALBUM_BAR);

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -53,6 +53,7 @@ export interface IBarMonthlySettlement { // 아티스트가 보는 바 차트
   month: number,
   settlement: number | null,
   revenue: number | null,
+  netIncome: number | null,
 }
 
 interface IRevenue { // 도넛 차트

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -122,7 +122,7 @@ export interface IAdminDashboardCard {
 
 // /api/v1/artist/{memberId}/dashboard
 export interface IArtistDashboardCard {
-  settlement: IEarnings,
+  settlementAmount: IEarnings,
   bestAlbum: IAlbum & {
     growthRate: number | null
   },
@@ -131,8 +131,10 @@ export interface IArtistDashboardCard {
   }
 }
 
-export interface IAlbumDashboardCard {
-  settlement: IEarnings
+export interface IAlbumDashboardCard extends IAlbum {
+  revenue: IEarnings,
+  netIncome: IEarnings,
+  settlementAmount: IEarnings,
   bestTrack: ITrack & {
     growthRate: number | null
   }

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -3,23 +3,22 @@ import {
   AdminType, ArtistRole, UserType,
 } from "@/types/enums/user.enum";
 
+interface IName {
+  name: string,
+  enName: string,
+}
+
 // 이름 관련
-export interface IArtist {
+export interface IArtist extends IName {
   memberId: number,
-  koArtistName: string,
-  enArtistName: string
 }
 
-interface ITrack {
+interface ITrack extends IName {
   trackId: number,
-  koTrackName: string,
-  enTrackName: string
 }
 
-interface IAlbum {
+interface IAlbum extends IName {
   albumId: number,
-  koAlbumName: string,
-  enAlbumName: string
 }
 
 interface IEarnings {
@@ -83,30 +82,21 @@ export interface ITrackParticipantInfo {
   commissionRate: number | null
 }
 
-export interface ITrackInfo {
-  trackId: number
-  koTrackName: string,
-  enTrackName: string,
+export interface ITrackInfo extends ITrack {
   bluekeyOriginalTrack: boolean,
   participants: ITrackParticipantInfo[],
 }
 
 // /api/v1/albums/{albumId}
-export interface IAlbumInfo {
-  albumId: number,
+export interface IAlbumInfo extends IAlbum {
   albumImage: string | null,
-  koAlbumName: string,
-  enAlbumName: string,
   artist: IArtist | null, // 앨범 대표 아티스트가 없을 수도 있음
   tracks: ITrackInfo[]
 }
 
 // /api/v1/albums
-export interface IAlbumCard {
-  albumId: number,
+export interface IAlbumCard extends IAlbum {
   albumImage: string,
-  koAlbumName: string,
-  enName: string
 }
 
 // 대시보드 카드 관련
@@ -143,10 +133,7 @@ export interface IAlbumDashboardCard extends IAlbum {
 // 아티스트 현황
 // /api/v1/artist
 export interface IArtistList {
-  artist: {
-    memberId: number,
-    koArtistName: string,
-    enArtistName: string,
+  artist: IArtist & {
     profileImage: string | null
   },
   revenue: number | null,
@@ -215,10 +202,7 @@ export interface IAdminAccount {
   email: string,
 }
 
-export interface IArtistAccount {
-  memberId: number,
-  name: string,
-  enName: string,
+export interface IArtistAccount extends IArtist {
   loginId: string,
   email: string | null,
   commissionRate: number | null,

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -76,17 +76,18 @@ export interface ILineTrackSettlementTrends extends ITrack { // 꺾은 선 차�
 }
 
 // Info 관련
+export interface ITrackParticipantInfo {
+  memberId: number,
+  name: string,
+  commissionRate: number | null
+}
+
 export interface ITrackInfo {
   trackId: number
   koTrackName: string,
   enTrackName: string,
   bluekeyOriginalTrack: boolean,
-  participants: {
-    memberId: number,
-    koArtistName: string,
-    enArtistName: string,
-    commissionRate: number | null
-  }[]
+  participants: ITrackParticipantInfo[],
 }
 
 // /api/v1/albums/{albumId}

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -198,8 +198,9 @@ interface ITransactionUploadAlert {
 export interface ITransactionUpload {
   id: number,
   name: string,
-  uploadAt: string
-  warnings: ITransactionUploadAlert[]
+  uploadAt: string,
+  warnings?: ITransactionUploadAlert[],
+  errors?: ITransactionUploadAlert[],
 }
 
 // 계정 관련


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

#### 변경 api 내용 반영
- 추가된 GET api
    - 어드민 프로필 조회
    - 아티스트 프로필 조회
    - 어드민 페이지 접근 허용 여부 체크
- 대시보드 필드 수정
    - 막대 차트와 라인 차트가 멤버 타입 상관 없이 회사이익까지 받도록 필드 추가
    - 앨범 대시보드 카드에 어드민이 받을 수 있는 내용들 필드 추가
- 드롭다운에 쓰이는 아티스트 목록에 요율 필드 추가

#### DTO 필드명 통일
- 이름 필드 명을 name, enName으로 통일

### How it Works
<!-- 간단한 로직 설명 -->

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->

BPS-236브랜치(=#90 PR)에서 이어진 작업이라, 해당 커밋 내용까지 포함된 상황입니다.
해당 PR이 리뷰돼서 머지되면 해당 브랜치만의 작업으로만 보여질 것 같습니다.