### PR TITLE
BPS-267/내 프로필 페이지 프로필 정보 수정 api, 비밀번호 재설정 api 연동

### DIFF
--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -4,8 +4,7 @@ import classNames from "classnames/bind";
 
 import Button from "@/components/common/CommonBtns/Button/Button";
 import PasswordField from "@/components/common/Inputs/PasswordInput/PasswordField";
-import useAlertModal from "@/hooks/useAlertModal";
-import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import useConfirmPassword from "@/services/queries/auth/useConfirmPassword";
 
 import styles from "./CurrentPasswordForm.module.scss";
 
@@ -21,17 +20,13 @@ interface CurrentPasswordFormProps {
 
 const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
   const { register, formState: { errors }, handleSubmit } = useForm<IChangePasswordFieldValues>();
-  const { showAlertModal } = useAlertModal();
-  const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = (data) => {
-    // TODO: /api/v1/auth/member/password/confirm 에 POST요청해서 response에 따라 성공, 에러 처리
-    if (data.password === "1234qwer") {
+  const { mutateAsync: confirmPassword } = useConfirmPassword();
+  const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = async (data) => {
+    try {
+      await confirmPassword(data);
       onSuccess();
-    } else {
-      showAlertModal({
-        type: MODAL_TYPE.ERROR,
-        title: "비밀번호 오류",
-        message: "입력하신 비밀번호와 현재 비밀번호가 일치하지 않습니다.",
-      });
+    } catch (err) {
+      console.error(err);
     }
   };
   return (

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -20,14 +20,10 @@ interface CurrentPasswordFormProps {
 
 const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
   const { register, formState: { errors }, handleSubmit } = useForm<IChangePasswordFieldValues>();
-  const { mutateAsync: confirmPassword } = useConfirmPassword();
+  const { mutateAsync: confirmPassword, isSuccess } = useConfirmPassword();
   const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = async (data) => {
-    try {
-      await confirmPassword(data);
-      onSuccess();
-    } catch (err) {
-      console.error(err);
-    }
+    await confirmPassword(data);
+    if (isSuccess) onSuccess();
   };
   return (
     <>

--- a/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/CurrentPasswordForm/CurrentPasswordForm.tsx
@@ -20,10 +20,14 @@ interface CurrentPasswordFormProps {
 
 const CurrentPasswordForm = ({ onSuccess }: CurrentPasswordFormProps) => {
   const { register, formState: { errors }, handleSubmit } = useForm<IChangePasswordFieldValues>();
-  const { mutateAsync: confirmPassword, isSuccess } = useConfirmPassword();
+  const { mutateAsync: confirmPassword } = useConfirmPassword();
   const handleClickNext: SubmitHandler<IChangePasswordFieldValues> = async (data) => {
-    await confirmPassword(data);
-    if (isSuccess) onSuccess();
+    try {
+      await confirmPassword(data);
+      onSuccess();
+    } catch (err) {
+      console.error(err);
+    }
   };
   return (
     <>

--- a/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
@@ -19,10 +19,14 @@ const NewPasswordForm = ({ onSuccess }: { onSuccess: () => void }) => {
   const {
     register, formState: { errors }, handleSubmit, getValues,
   } = useForm<INewPasswordFieldValues>({ mode: "onBlur" });
-  const { mutateAsync: changePassword, isSuccess } = useChangePassword();
+  const { mutateAsync: changePassword } = useChangePassword();
   const handleClickDone: SubmitHandler<INewPasswordFieldValues> = async (data) => {
-    await changePassword({ password: data.password });
-    if (isSuccess) onSuccess();
+    try {
+      await changePassword({ password: data.password });
+      onSuccess();
+    } catch (err) {
+      console.error(err);
+    }
   };
   return (
     <>

--- a/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
+++ b/src/components/auth/ChangePasswordForm/NewPasswordForm/NewPasswordForm.tsx
@@ -4,8 +4,7 @@ import classNames from "classnames/bind";
 
 import Button from "@/components/common/CommonBtns/Button/Button";
 import PasswordField from "@/components/common/Inputs/PasswordInput/PasswordField";
-import useAlertModal from "@/hooks/useAlertModal";
-import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import useChangePassword from "@/services/queries/auth/useChangePassword";
 
 import styles from "../CurrentPasswordForm/CurrentPasswordForm.module.scss";
 
@@ -20,19 +19,10 @@ const NewPasswordForm = ({ onSuccess }: { onSuccess: () => void }) => {
   const {
     register, formState: { errors }, handleSubmit, getValues,
   } = useForm<INewPasswordFieldValues>({ mode: "onBlur" });
-  const { showAlertModal } = useAlertModal();
-  const handleClickDone: SubmitHandler<INewPasswordFieldValues> = (data) => {
-    // TODO: /api/v1/auth/member/password 로 patch요청 try-catch
-    if (data.password === "1234qwer") {
-      onSuccess();
-    } else {
-      showAlertModal({
-        type: MODAL_TYPE.ERROR,
-        title: "에러 발생",
-        message: `알 수 없는 에러가 발생하였습니다. 
-        잠시 후에 다시 시도해주세요.`,
-      });
-    }
+  const { mutateAsync: changePassword, isSuccess } = useChangePassword();
+  const handleClickDone: SubmitHandler<INewPasswordFieldValues> = async (data) => {
+    await changePassword({ password: data.password });
+    if (isSuccess) onSuccess();
   };
   return (
     <>

--- a/src/components/my-profile/AdminProfileForm/AdminProfileForm.tsx
+++ b/src/components/my-profile/AdminProfileForm/AdminProfileForm.tsx
@@ -66,7 +66,7 @@ const AdminProfileForm = ({ loginId, onSubmit }: AdminProfileFormProps) => {
             onBlur: () => { void trigger("nickname"); },
           })}
           errors={errors}
-          onSave={() => { onSubmit(getValues()); }}
+          onSave={() => { onSubmit({ file: null, nickname: getValues("nickname") }); }}
           originalValue={defaultValues?.nickname}
           resetField={resetField as UseFormResetField<FieldValues>}
         />
@@ -83,7 +83,7 @@ const AdminProfileForm = ({ loginId, onSubmit }: AdminProfileFormProps) => {
             onBlur: () => { void trigger("email"); },
           })}
           errors={errors}
-          onSave={() => { onSubmit(getValues()); }}
+          onSave={() => { onSubmit({ file: null, email: getValues("email") }); }}
           originalValue={defaultValues?.email ?? ""}
           resetField={resetField as UseFormResetField<FieldValues>}
         />

--- a/src/components/my-profile/ArtistProfileForm/ArtistProfileForm.tsx
+++ b/src/components/my-profile/ArtistProfileForm/ArtistProfileForm.tsx
@@ -79,7 +79,7 @@ const ArtistProfileForm = ({
           })}
           errors={errors}
           bottomText="*해당 메일로 정산 완료 메일이 발송됩니다"
-          onSave={() => { onSubmit(getValues()); }}
+          onSave={() => { onSubmit({ file: null, email: getValues("email") }); }}
           originalValue={defaultValues?.email ?? ""}
           resetField={resetField as UseFormResetField<FieldValues>}
         />

--- a/src/pages/admin/my-profile/index.page.tsx
+++ b/src/pages/admin/my-profile/index.page.tsx
@@ -21,12 +21,9 @@ const AdminMyProfilePage = () => {
   const userInfo = useAppSelector((state) => { return state.user.member as IAdminProfile; });
   // 프로필 정보(닉네임, 이메일) 수정 쿼리
   const {
-    mutate, isLoading,
+    mutate: updateProfile, isLoading,
   } = useUpdateAdminMyProfileInfo();
-  // 프로밀 이미지 수정 쿼리
-  const {
-    mutateAsync: mutateImageAsync,
-  } = useUpdateAdminProfileImage();
+  const { mutateAsync: updateProfileImage } = useUpdateAdminProfileImage();
   const methods = useForm<IAdminUpdateProfileFieldValues>({
     defaultValues: {
       email: userInfo.email,
@@ -35,13 +32,11 @@ const AdminMyProfilePage = () => {
   });
 
   const onSubmit:SubmitHandler<IAdminUpdateProfileFieldValues> = (data) => {
-    mutate(data);
-    // eslint-disable-next-line no-console
-    console.log(data);
+    updateProfile(data);
   };
 
   const handleUploadImage = async (file: File) => {
-    await mutateImageAsync({ profileImage: file });
+    await updateProfileImage({ file });
   };
 
   return (
@@ -53,7 +48,7 @@ const AdminMyProfilePage = () => {
               <div className={cx("imageUploadContainer")}>
                 <ImageUploader
                   shape="circle"
-                  {...methods.register("profileImage")}
+                  {...methods.register("file")}
                   onUpload={handleUploadImage}
                   defaultUrl={userInfo.profileImage}
                 />

--- a/src/pages/artists/[artistId]/my-profile/index.page.tsx
+++ b/src/pages/artists/[artistId]/my-profile/index.page.tsx
@@ -21,11 +21,11 @@ const ArtistMyProfilePage = () => {
   const userInfo = useAppSelector((state) => { return state.user.member as IArtistProfile; });
   // 프로필 정보(닉네임, 이메일) 수정 쿼리
   const {
-    mutate, isLoading,
+    mutate: updateProfile, isLoading,
   } = useUpdateArtistMyProfileInfo();
   // 프로밀 이미지 수정 쿼리
   const {
-    mutateAsync: mutateImageAsync,
+    mutateAsync: updateProfileImage,
   } = useUpdateArtistMyProfileImage();
 
   const methods = useForm<IArtistUpdateProfileFieldValues>({
@@ -35,11 +35,11 @@ const ArtistMyProfilePage = () => {
   });
 
   const onSubmit: SubmitHandler<IArtistUpdateProfileFieldValues> = (data) => {
-    mutate(data);
+    updateProfile(data);
   };
 
   const handleUploadImage = async (file: File) => {
-    await mutateImageAsync({ profileImage: file });
+    await updateProfileImage({ file });
   };
 
   return (
@@ -51,7 +51,7 @@ const ArtistMyProfilePage = () => {
               <div className={cx("imageUploadContainer")}>
                 <ImageUploader
                   shape="circle"
-                  {...methods.register("profileImage")}
+                  {...methods.register("file")}
                   onUpload={handleUploadImage}
                   defaultUrl={userInfo.profileImage}
                 />

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -103,6 +103,7 @@ export const wrapper = createWrapper<Store>(makeStore);
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 export type AppStore = ReturnType<typeof makeStore>;
+export type TestStore = ReturnType<typeof setupStore>;
 export type AppState = ReturnType<AppStore["getState"]>;
 export type RootReducer = ReturnType<typeof rootReducer>;
 

--- a/src/services/api/requests/artist/artist.patch.api.ts
+++ b/src/services/api/requests/artist/artist.patch.api.ts
@@ -34,7 +34,7 @@ export const patchArtistProfile = async (
   });
   formData.append("data", JSON.stringify(dataList));
 
-  const response = await patchRequest<IPatchArtistProfileResponse, FormData>("/artist/profile", formData, {
+  const response = await patchRequest<IPatchArtistProfileResponse, FormData>("/artists/profile", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },

--- a/src/services/api/requests/auth/auth.patch.api.ts
+++ b/src/services/api/requests/auth/auth.patch.api.ts
@@ -1,12 +1,12 @@
 import { IPatchChangePasswordRequest } from "../../types/auth";
-import { postRequest } from "../requests.api";
+import { patchRequest } from "../requests.api";
 
 /* 비밀번호 변경 */
 export const changePassword = async ({
   password,
 }: IPatchChangePasswordRequest) => {
   // 200번 response data 확인 요망
-  const response = await postRequest<string, IPatchChangePasswordRequest>("/auth/member/password", {
+  const response = await patchRequest<string, IPatchChangePasswordRequest>("/auth/member/password", {
     password,
   });
   return response;

--- a/src/services/queries/auth/useChangePassword.ts
+++ b/src/services/queries/auth/useChangePassword.ts
@@ -2,20 +2,20 @@ import { useMutation } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 
 import useAlertModal from "@/hooks/useAlertModal";
-import { confirmPassword } from "@/services/api/requests/auth/auth.post.api";
+import { changePassword } from "@/services/api/requests/auth/auth.patch.api";
 import { ICommonErrorResponse } from "@/services/api/types/global";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 import { isCommonError } from "@/utils/type.predicates";
 
-const useConfirmPassword = () => {
+const useChangePassword = () => {
   const { showAlertModal } = useAlertModal();
-  const mutation = useMutation(confirmPassword, {
+  const mutation = useMutation(changePassword, {
     onError: (err) => {
       if (isAxiosError<ICommonErrorResponse>(err)) {
         if (isCommonError(err.response?.data)) {
           showAlertModal({
             type: MODAL_TYPE.ERROR,
-            title: "비밀번호 확인 에러",
+            title: "비밀번호 재설정 에러",
             message: err.response?.data.message ?? "알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도하세요.",
           });
         }
@@ -25,4 +25,4 @@ const useConfirmPassword = () => {
   return mutation;
 };
 
-export default useConfirmPassword;
+export default useChangePassword;

--- a/src/services/queries/auth/useConfirmPassword.ts
+++ b/src/services/queries/auth/useConfirmPassword.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+
+import useAlertModal from "@/hooks/useAlertModal";
+import { confirmPassword } from "@/services/api/requests/auth/auth.post.api";
+import { ICommonErrorResponse } from "@/services/api/types/global";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import { isCommonError } from "@/utils/type.predicates";
+
+const useConfirmPassword = () => {
+  const { showAlertModal } = useAlertModal();
+  const mutation = useMutation(confirmPassword, {
+    onError: (err) => {
+      if (isAxiosError<ICommonErrorResponse>(err)) {
+        if (isCommonError(err.response?.data)) {
+          showAlertModal({
+            type: MODAL_TYPE.ERROR,
+            title: "비밀번호 확인 에러",
+            message: err.response?.data.message ?? "알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도하세요.",
+          });
+        }
+      }
+    },
+  });
+  return mutation;
+};
+
+export default useConfirmPassword;

--- a/src/services/queries/my-profile/useUpdateProfile.ts
+++ b/src/services/queries/my-profile/useUpdateProfile.ts
@@ -1,64 +1,24 @@
 /* eslint-disable no-void */
 import { useMutation } from "@tanstack/react-query";
 
-import useAlertModal from "@/hooks/useAlertModal";
+import useAlertModal, { IShowAlertModalParam } from "@/hooks/useAlertModal";
 import useToast from "@/hooks/useToast";
 import { useAppDispatch } from "@/redux/hooks";
 import { setUser } from "@/redux/slices/userSlice";
-import { IAdminProfile, IArtistProfile } from "@/types/dto";
+import { patchAdminProfile } from "@/services/api/requests/admin/admin.patch.api";
+import { IPatchAdminProfileData, IPatchAdminProfileResponse } from "@/services/api/types/admin";
+import { IPatchArtistProfileData, IPatchArtistProfileResponse } from "@/services/api/types/artist";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
-import { MEMBER_ROLE, MEMBER_TYPE } from "@/types/enums/user.enum";
+import { MEMBER_TYPE } from "@/types/enums/user.enum";
 
-interface IPatchAdminMyProfileRequest {
-  profileImage: File | null,
-  email?: string,
-  nickname?: string,
-}
+import { patchArtistProfile } from "../../api/requests/artist/artist.patch.api";
 
-interface IPatchAdminMyProfileResponse extends IAdminProfile { }
-
-interface IPatchArtistMyProfileRequest extends Omit<IPatchAdminMyProfileRequest, "nickname"> { }
-
-interface IPatchArtistMyProfileResponse extends IArtistProfile { }
-
-const patchAdminMyProfile = (
-  body: IPatchAdminMyProfileRequest,
-): Promise<IPatchAdminMyProfileResponse> => {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      void body;
-      return resolve({
-        memberId: 1,
-        role: MEMBER_ROLE.ADMIN,
-        type: MEMBER_TYPE.ADMIN,
-        email: "example@bluekey_domain.com",
-        loginId: "sapidjsaio",
-        nickname: "블루키",
-        profileImage: "https://s3...",
-      });
-      reject(new Error("에러가 발생했습니다."));
-    }, 2000);
-  });
-};
-
-const patchArtistMyProfile = (
-  body: IPatchArtistMyProfileRequest,
-): Promise<IPatchArtistMyProfileResponse> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      void body;
-      return resolve({
-        memberId: 1,
-        role: MEMBER_ROLE.ARTIST,
-        type: MEMBER_TYPE.USER,
-        email: "example@bluekey_domain.com",
-        loginId: "dfjalke",
-        name: "블루키",
-        enName: "bluekey",
-        profileImage: "https://s3...",
-      });
-    }, 2000);
-  });
+const getErrorModalInfo = (message: string, title = "프로필 수정 에러"): IShowAlertModalParam => {
+  return {
+    type: MODAL_TYPE.ERROR,
+    title,
+    message,
+  };
 };
 
 export const useUpdateAdminMyProfileInfo = () => {
@@ -66,24 +26,20 @@ export const useUpdateAdminMyProfileInfo = () => {
   const { showToast } = useToast();
   const { showAlertModal } = useAlertModal();
   const mutation = useMutation<
-  IPatchAdminMyProfileResponse,
+  IPatchAdminProfileResponse,
   unknown,
-  IPatchAdminMyProfileRequest,
+  IPatchAdminProfileData,
   unknown
   >(
     ["admin", "my-profile"],
-    patchAdminMyProfile,
+    patchAdminProfile,
     {
       onSuccess: (data) => {
         showToast("프로필 정보가 수정되었습니다.");
-        dispatch(setUser(data));
+        dispatch(setUser({ ...data, type: MEMBER_TYPE.ADMIN }));
       },
       onError: () => {
-        showAlertModal({
-          type: MODAL_TYPE.ERROR,
-          title: "프로필 수정 에러",
-          message: "알 수 없는 에러가 발생하였습니다. 잠시 후에 다시 시도해주세요.",
-        });
+        showAlertModal(getErrorModalInfo("알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도해 주세요."));
       },
     },
   );
@@ -93,18 +49,22 @@ export const useUpdateAdminMyProfileInfo = () => {
 export const useUpdateAdminProfileImage = () => {
   const dispatch = useAppDispatch();
   const { showToast } = useToast();
+  const { showAlertModal } = useAlertModal();
   const mutation = useMutation<
-  IPatchAdminMyProfileResponse,
+  IPatchAdminProfileResponse,
   unknown,
-  Pick<IPatchAdminMyProfileRequest, "profileImage">,
+  IPatchAdminProfileData,
   unknown
   >(
     ["admin", "my-profile", "profile-image"],
-    patchAdminMyProfile,
+    patchAdminProfile,
     {
       onSuccess: (data) => {
         showToast("프로필 이미지가 변경되었습니다.");
-        dispatch(setUser(data));
+        dispatch(setUser({ ...data, type: MEMBER_TYPE.ADMIN }));
+      },
+      onError: () => {
+        showAlertModal(getErrorModalInfo("알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도해 주세요."));
       },
     },
   );
@@ -114,18 +74,22 @@ export const useUpdateAdminProfileImage = () => {
 export const useUpdateArtistMyProfileInfo = () => {
   const dispatch = useAppDispatch();
   const { showToast } = useToast();
+  const { showAlertModal } = useAlertModal();
   const mutation = useMutation<
-  IPatchArtistMyProfileResponse,
+  IPatchArtistProfileResponse,
   unknown,
-  IPatchArtistMyProfileRequest,
+  IPatchArtistProfileData,
   unknown
   >(
     ["artist", "my-profile"],
-    patchArtistMyProfile,
+    patchArtistProfile,
     {
       onSuccess: (data) => {
         showToast("프로필 정보가 수정되었습니다.");
-        dispatch(setUser(data));
+        dispatch(setUser({ ...data, type: MEMBER_TYPE.USER }));
+      },
+      onError: () => {
+        showAlertModal(getErrorModalInfo("알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도해 주세요."));
       },
     },
   );
@@ -135,18 +99,22 @@ export const useUpdateArtistMyProfileInfo = () => {
 export const useUpdateArtistMyProfileImage = () => {
   const dispatch = useAppDispatch();
   const { showToast } = useToast();
+  const { showAlertModal } = useAlertModal();
   const mutation = useMutation<
-  IPatchArtistMyProfileResponse,
+  IPatchArtistProfileResponse,
   unknown,
-  Pick<IPatchArtistMyProfileRequest, "profileImage">,
+  IPatchArtistProfileData,
   unknown
   >(
     ["artist", "my-profile", "profile-image"],
-    patchArtistMyProfile,
+    patchArtistProfile,
     {
       onSuccess: (data) => {
         showToast("프로필 이미지가 변경되었습니다.");
-        dispatch(setUser(data));
+        dispatch(setUser({ ...data, type: MEMBER_TYPE.USER }));
+      },
+      onError: () => {
+        showAlertModal(getErrorModalInfo("알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도해 주세요."));
       },
     },
   );

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -171,8 +171,8 @@ export interface IArtistProfile extends IProfile {
 }
 
 export interface IArtistUpdateProfileFieldValues {
-  email?: string
-  profileImage: File | null;
+  email: string
+  file: File | null;
 }
 
 // 정산액 업로드 관련

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -159,7 +159,7 @@ export interface IAdminProfile extends IProfile {
 }
 
 export interface IAdminUpdateProfileFieldValues extends Partial<Pick<IAdminProfile, "email" | "nickname">> {
-  profileImage: File | null,
+  file: File | null,
 }
 
 export interface IArtistProfile extends IProfile {

--- a/src/utils/test.utils.tsx
+++ b/src/utils/test.utils.tsx
@@ -8,11 +8,13 @@ import { Provider } from "react-redux";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "@testing-library/react";
 
-import { setupStore, type AppStore, type RootState } from "@/redux/store";
+import {
+  setupStore, type RootState, TestStore,
+} from "@/redux/store";
 
 interface ExtendedRenderOptions extends Omit<RenderOptions, "queries"> {
   preloadedState?: PreloadedState<RootState>
-  store?: AppStore
+  store?: TestStore
 }
 
 const renderWithProviders = (


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 어드민, 아티스트 내 프로필 페이지에 수정 기능 관련 api를 연동했습니다. 
- 비밀번호 재설정 모달 기능에 필요한 api를 연동했습니다.
### How it Works
<!-- 간단한 로직 설명 -->
- 수정 가능한 필드마다 수정 모드가 있는 TextField를 렌더링 합니다. focus시 입력이 가능하고 수정 버튼이 나타나며 버튼을 누를 시 해당 필드만 body에 담아 수정 요청을 보내게 됩니다. 
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/e68c4c09-eaa7-473b-9d0b-5428dce01c75)
- 프로필 이미지는 벨로그 사이트 프로필 이미지 변경 로직과 동일합니다. 이미지를 변경하면 바로 patch요청이 가게 됩니다. 

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
- 비밀번호 재설정 모달의 경우 현재 비밀번호 확인 api는 잘 동작하지만 비밀번호 재설정 요청(patch member password)이 500에러를 반환하고 있는 상태라 서버 버그로 생각하고 있습니다. 백엔드 측에 보수를 요청할 계획입니다. 
