### PR TITLE
BPS-185/토스트 컴포넌트 리뉴얼

### DIFF
--- a/src/components/common/Toast/Toast.module.scss
+++ b/src/components/common/Toast/Toast.module.scss
@@ -26,7 +26,7 @@
   width: 385px;
   height: 71px;
   padding: 27px 20px;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   border-radius: 6px;
   background: #575757;
   gap: 30px;

--- a/src/components/common/Toast/Toast.module.scss
+++ b/src/components/common/Toast/Toast.module.scss
@@ -25,17 +25,24 @@
   z-index: 100;
   width: 385px;
   height: 71px;
-  padding: 27px 20px;
+  padding: 6px 20px 6px 8px;
   transform: translateX(-50%);
   border-radius: 6px;
   background: #575757;
-  gap: 30px;
+  gap: 14.5px;
 
-  .iconBox {
-    position: relative;
-    z-index: 1000;
-    width: 15px;
-    height: 17px;
+  .statusBar {
+    width: 6px;
+    height: 100%;
+    border-radius: 3px;
+
+    &.success {
+      background-color: $point-color-green2;
+    }
+
+    &.fail {
+      background-color: $point-color-red2;
+    }
   }
 
   & span {
@@ -45,6 +52,7 @@
     color: $primary-white;
     line-height: 26px;
     text-align: center;
+    vertical-align: center;
   }
 }
 

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -3,7 +3,8 @@ import {
 } from "react";
 
 import classNames from "classnames/bind";
-import Image from "next/image";
+
+import { ToastStatus } from "@/types/enums/toast.enum";
 
 import styles from "./Toast.module.scss";
 
@@ -13,17 +14,23 @@ const cx = classNames.bind(styles);
  * 토스트 컴포넌트
  * @author [SeyoungCho](https://github.com/seyoungcho)
  * @param {string } message - 토스트 메세지
+ * @param {ToastStatus} status - 토스트 상태 - SUCCESS(초록색 바), FAIL(빨간색 바))
  * @example
  *
  * ```
  * <ToastPortal>
- *   <Toast message="완료되었습니다" />
+ *   <Toast message="완료되었습니다" status="SUCCESS" />
  * </ToastPortal>
  *```
  */
+interface ToastProps {
+  message: string;
+  status: ToastStatus
+}
+
 const Toast = forwardRef(
   (
-    { message }: { message: string },
+    { message, status }: ToastProps,
     ref: ForwardedRef<HTMLDialogElement>,
   ) => {
     const [isShowing, setIsShowing] = useState(true);
@@ -46,9 +53,7 @@ const Toast = forwardRef(
           fadeOut: !isShowing,
         })}
         >
-          <div className={cx("iconBox")}>
-            <Image src="/images/lightening.png" alt="번개 아이콘" sizes="64vw" fill />
-          </div>
+          <div className={cx("statusBar", { success: status === "SUCCESS" }, { fail: status === "FAIL" })} />
           <span>{message}</span>
         </div>
       </dialog>

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import {
+  ForwardedRef, forwardRef, useEffect, useState,
+} from "react";
 
 import classNames from "classnames/bind";
 import Image from "next/image";
@@ -19,32 +21,39 @@ const cx = classNames.bind(styles);
  * </ToastPortal>
  *```
  */
-const Toast = ({ message }: { message: string }) => {
-  const [isShowing, setIsShowing] = useState(true);
+const Toast = forwardRef(
+  (
+    { message }: { message: string },
+    ref: ForwardedRef<HTMLDialogElement>,
+  ) => {
+    const [isShowing, setIsShowing] = useState(true);
 
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setIsShowing(false);
-    }, 2800);
+    useEffect(() => {
+      const timeout = setTimeout(() => {
+        setIsShowing(false);
+      }, 2800);
 
-    return () => { return clearTimeout(timeout); };
-  }, []);
+      return () => { return clearTimeout(timeout); };
+    }, []);
 
-  return (
-    <div
-      className={
-          cx(styles.toastContainer, {
-            [styles.fadeIn]: isShowing,
-            [styles.fadeOut]: !isShowing,
-          })
-        }
-    >
-      <div className={cx(styles.iconBox)}>
-        <Image src="/images/lightening.png" alt="번개 아이콘" sizes="64vw" fill />
-      </div>
-      <span>{message}</span>
-    </div>
-  );
-};
+    return (
+      <dialog
+        ref={ref}
+        open
+      >
+        <div className={cx("toastContainer", {
+          fadeIn: isShowing,
+          fadeOut: !isShowing,
+        })}
+        >
+          <div className={cx("iconBox")}>
+            <Image src="/images/lightening.png" alt="번개 아이콘" sizes="64vw" fill />
+          </div>
+          <span>{message}</span>
+        </div>
+      </dialog>
+    );
+  },
+);
 
 export default Toast;

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,6 +1,4 @@
-import {
-  ForwardedRef, forwardRef, useEffect, useState,
-} from "react";
+import { useEffect, useState } from "react";
 
 import classNames from "classnames/bind";
 
@@ -28,37 +26,27 @@ interface ToastProps {
   status: ToastStatus
 }
 
-const Toast = forwardRef(
-  (
-    { message, status }: ToastProps,
-    ref: ForwardedRef<HTMLDialogElement>,
-  ) => {
-    const [isShowing, setIsShowing] = useState(true);
+const Toast = ({ message, status }: ToastProps) => {
+  const [isShowing, setIsShowing] = useState(true);
 
-    useEffect(() => {
-      const timeout = setTimeout(() => {
-        setIsShowing(false);
-      }, 2800);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setIsShowing(false);
+    }, 2800);
 
-      return () => { return clearTimeout(timeout); };
-    }, []);
+    return () => { return clearTimeout(timeout); };
+  }, []);
 
-    return (
-      <dialog
-        ref={ref}
-        open
-      >
-        <div className={cx("toastContainer", {
-          fadeIn: isShowing,
-          fadeOut: !isShowing,
-        })}
-        >
-          <div className={cx("statusBar", { success: status === "SUCCESS" }, { fail: status === "FAIL" })} />
-          <span>{message}</span>
-        </div>
-      </dialog>
-    );
-  },
-);
+  return (
+    <div className={cx("toastContainer", {
+      fadeIn: isShowing,
+      fadeOut: !isShowing,
+    })}
+    >
+      <div className={cx("statusBar", { success: status === "SUCCESS" }, { fail: status === "FAIL" })} />
+      <span>{message}</span>
+    </div>
+  );
+};
 
 export default Toast;

--- a/src/components/common/Toast/ToastPortal.tsx
+++ b/src/components/common/Toast/ToastPortal.tsx
@@ -1,14 +1,18 @@
 import { ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
-const ToastPortal = ({ children }: { children: ReactNode }) => {
+interface ToastPortalProps {
+  portalId: string;
+  children: ReactNode;
+}
+
+const ToastPortal = ({ portalId, children }: ToastPortalProps) => {
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
     return () => { return setMounted(false); };
   }, []);
-
-  const el = typeof window !== "undefined" && document.getElementById("toast-root");
+  const el = typeof window !== "undefined" && document.getElementById(portalId);
   if (!mounted) return null;
   return createPortal(children, el as HTMLElement);
 };

--- a/src/components/common/Toast/ToastRoot.tsx
+++ b/src/components/common/Toast/ToastRoot.tsx
@@ -6,19 +6,19 @@ import Toast from "./Toast";
 import ToastPortal from "./ToastPortal";
 
 const ToastRoot = () => {
-  const isVisible = useAppSelector((state) => { return state.toast.isShowing; });
-  const message = useAppSelector((state) => { return state.toast.message; });
-  const portalId = useAppSelector((state) => { return state.toast.portalId; });
+  const {
+    isShowing, message, portalId, status,
+  } = useAppSelector((state) => { return state.toast; });
   const toastRef = useRef<HTMLDialogElement>(null);
   useEffect(() => {
-    if (isVisible) {
+    if (isShowing) {
       toastRef.current?.show();
     }
-  }, [isVisible]);
-  if (!isVisible) return null;
+  }, [isShowing]);
+  if (!isShowing) return null;
   return (
     <ToastPortal portalId={portalId}>
-      <Toast ref={toastRef} message={message} />
+      <Toast ref={toastRef} message={message} status={status} />
     </ToastPortal>
   );
 };

--- a/src/components/common/Toast/ToastRoot.tsx
+++ b/src/components/common/Toast/ToastRoot.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import { useAppSelector } from "@/redux/hooks";
 
 import Toast from "./Toast";
@@ -6,14 +8,19 @@ import ToastPortal from "./ToastPortal";
 const ToastRoot = () => {
   const isVisible = useAppSelector((state) => { return state.toast.isShowing; });
   const message = useAppSelector((state) => { return state.toast.message; });
-  if (isVisible) {
-    return (
-      <ToastPortal>
-        <Toast message={message} />
-      </ToastPortal>
-    );
-  }
-  return null;
+  const portalId = useAppSelector((state) => { return state.toast.portalId; });
+  const toastRef = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    if (isVisible) {
+      toastRef.current?.show();
+    }
+  }, [isVisible]);
+  if (!isVisible) return null;
+  return (
+    <ToastPortal portalId={portalId}>
+      <Toast ref={toastRef} message={message} />
+    </ToastPortal>
+  );
 };
 
 export default ToastRoot;

--- a/src/components/common/Toast/ToastRoot.tsx
+++ b/src/components/common/Toast/ToastRoot.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from "react";
-
 import { useAppSelector } from "@/redux/hooks";
 
 import Toast from "./Toast";
@@ -9,16 +7,10 @@ const ToastRoot = () => {
   const {
     isShowing, message, portalId, status,
   } = useAppSelector((state) => { return state.toast; });
-  const toastRef = useRef<HTMLDialogElement>(null);
-  useEffect(() => {
-    if (isShowing) {
-      toastRef.current?.show();
-    }
-  }, [isShowing]);
   if (!isShowing) return null;
   return (
     <ToastPortal portalId={portalId}>
-      <Toast ref={toastRef} message={message} status={status} />
+      <Toast message={message} status={status} />
     </ToastPortal>
   );
 };

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,17 +1,21 @@
 import { useAppDispatch } from "@/redux/hooks";
-import { setProtalId, setShow, setToastMessage } from "@/redux/slices/toastSlice";
+import {
+  setProtalId, setShow, setStatus, setToastMessage,
+} from "@/redux/slices/toastSlice";
+import { ToastStatus } from "@/types/enums/toast.enum";
 
 const useToast = () => {
   const dispatch = useAppDispatch();
 
-  const showToast = (message: string, portalId = "toast-root") => {
+  const showToast = (message: string, portalId = "toast-root", status: ToastStatus = "SUCCESS") => {
     dispatch(setToastMessage(message));
     dispatch(setProtalId(portalId));
+    dispatch(setStatus(status));
     dispatch(setShow(true));
 
-    setTimeout(() => {
-      dispatch(setShow(false));
-    }, 3000);
+    // setTimeout(() => {
+    //   dispatch(setShow(false));
+    // }, 3000);
   };
 
   return { showToast };

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,11 +1,12 @@
 import { useAppDispatch } from "@/redux/hooks";
-import { setShow, setToastMessage } from "@/redux/slices/toastSlice";
+import { setProtalId, setShow, setToastMessage } from "@/redux/slices/toastSlice";
 
 const useToast = () => {
   const dispatch = useAppDispatch();
 
-  const showToast = (message: string) => {
+  const showToast = (message: string, portalId = "toast-root") => {
     dispatch(setToastMessage(message));
+    dispatch(setProtalId(portalId));
     dispatch(setShow(true));
 
     setTimeout(() => {

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -13,9 +13,9 @@ const useToast = () => {
     dispatch(setStatus(status));
     dispatch(setShow(true));
 
-    // setTimeout(() => {
-    //   dispatch(setShow(false));
-    // }, 3000);
+    setTimeout(() => {
+      dispatch(setShow(false));
+    }, 3000);
   };
 
   return { showToast };

--- a/src/redux/slices/toastSlice.ts
+++ b/src/redux/slices/toastSlice.ts
@@ -4,11 +4,13 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 export interface IToastState {
   isShowing: boolean;
   message: string;
+  portalId: string;
 }
 
 const initialState: IToastState = {
   isShowing: false,
   message: "",
+  portalId: "toast-portal",
 };
 
 export const toastSlice = createSlice({
@@ -21,9 +23,12 @@ export const toastSlice = createSlice({
     setToastMessage: (state, action: PayloadAction<string>) => {
       state.message = action.payload;
     },
+    setProtalId: (state, action: PayloadAction<string>) => {
+      state.portalId = action.payload;
+    },
   },
 });
 
-export const { setShow, setToastMessage } = toastSlice.actions;
+export const { setShow, setToastMessage, setProtalId } = toastSlice.actions;
 
 export default toastSlice.reducer;

--- a/src/redux/slices/toastSlice.ts
+++ b/src/redux/slices/toastSlice.ts
@@ -1,16 +1,20 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+import { ToastStatus } from "@/types/enums/toast.enum";
+
 export interface IToastState {
   isShowing: boolean;
   message: string;
   portalId: string;
+  status: ToastStatus
 }
 
 const initialState: IToastState = {
   isShowing: false,
   message: "",
   portalId: "toast-portal",
+  status: "SUCCESS",
 };
 
 export const toastSlice = createSlice({
@@ -26,9 +30,14 @@ export const toastSlice = createSlice({
     setProtalId: (state, action: PayloadAction<string>) => {
       state.portalId = action.payload;
     },
+    setStatus: (state, action: PayloadAction<ToastStatus>) => {
+      state.status = action.payload;
+    },
   },
 });
 
-export const { setShow, setToastMessage, setProtalId } = toastSlice.actions;
+export const {
+  setShow, setToastMessage, setProtalId, setStatus,
+} = toastSlice.actions;
 
 export default toastSlice.reducer;

--- a/src/types/enums/toast.enum.ts
+++ b/src/types/enums/toast.enum.ts
@@ -1,0 +1,6 @@
+export const TOAST_STATUS = {
+  SUCCESS: "SUCCESS",
+  FAIL: "FAIL",
+} as const;
+
+export type ToastStatus = (typeof TOAST_STATUS)[keyof typeof TOAST_STATUS];


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 토스트 컴포넌트를 새롭게 리뉴얼 했습니다. 
- 토스트가 toast-root라는 id를 가진 div말고도 다른 요소 안에서도 렌더링 될 수 있게 변합니다.
- 새로운 디자인이 반영되었습니다. 
- 토스트 컴포넌트에 status라는 prop이 추가되었습니다. 초록색, 빨간색을 구분하는 prop입니다.

### How it Works
<!-- 간단한 로직 설명 -->
- 앞으로 showToast함수를 사용할 때, 함수의 두 번째 인자로 portald, 세 번째 인자로 status를 넘겨줄 수 있습니다. 
- portalId: 렌더링 하고자 하는 토스트를 렌더링할 부모 엘리먼트의 id값을 넘겨줄 수 있습니다. 생략되는 경우 기존의 toast-root를 portal삼아 렌더링 합니다. 모달이 항상 top-layer에 렌더링되어서 모달 안에서 글로벌 토스트를 show할 경우 (예: 2-step 모달) 토스트가 오버레이 뒤에서 렌더링 되는 버그가 있는데, 이제 showToast의 portalId 파라미터 자리에 모달의 id를 넘기면 모달 안에서 토스트가 렌더링 되어 오버레이 위에 나타나게 됩니다.
- status: "SUCCESS", "FAIL"로 토스트의 상태를 컬러로 표현합니다. 주로 작업 성공 또는 완료 알림 토스트는 SUCCESS를 주어 초록색을, 실패 알림은 FAIL을 주어 빨간색 바를 렌더링하게 합니다.

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
- 디자인 시안에 나온것 처럼 상태 컬러 바를 3px로 줬더니 너무 얇아 보이는 탓에 6px로 늘렸습니다. 의견 공유 부탁합니다. 
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/100fad98-e23c-4327-ba70-685a108e9bb9)
![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/48e9a37f-13c3-4723-8588-06582b3c14e7)
