### PR TITLE
BPS-322/프로덕션 환경에서 비밀번호란 폰트 미반영 현상 수정

### DIFF
--- a/src/components/common/Dropdown/DropdownUI.module.scss
+++ b/src/components/common/Dropdown/DropdownUI.module.scss
@@ -54,7 +54,7 @@
     }
 
     &.hasSearchBar {
-      width: 348px;
+      width: 100%;
       height: 47px;
       border: none;
       background-color: $sub-color1;

--- a/src/components/common/Filter/Filter.module.scss
+++ b/src/components/common/Filter/Filter.module.scss
@@ -14,12 +14,12 @@
 
     color: $primary-black;
   }
+}
 
-  .closeBtn {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 15px;
-    height: 15px;
-  }
+.closeBtn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 15px;
+  height: 15px;
 }

--- a/src/components/common/Filter/Filter.module.scss
+++ b/src/components/common/Filter/Filter.module.scss
@@ -14,4 +14,12 @@
 
     color: $primary-black;
   }
+
+  .closeBtn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 15px;
+    height: 15px;
+  }
 }

--- a/src/components/common/Filter/Filter.tsx
+++ b/src/components/common/Filter/Filter.tsx
@@ -1,16 +1,37 @@
+import { useState } from "react";
+
 import classNames from "classnames/bind";
 import Image from "next/image";
+
+import FilterForm from "@/components/common/Filter/FilterForm/FilterForm";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+
+import Modal from "../Modals/Modal";
 
 import styles from "./Filter.module.scss";
 
 const cx = classNames.bind(styles);
 
 const Filter = () => {
+  const [open, setOpen] = useState(false);
   return (
-    <button className={cx("container")} onClick={() => { }}>
-      <Image src="/images/filter.svg" width={11} height={11} alt="필터" />
-      <span className={cx("text")}>필터</span>
-    </button>
+    <>
+      <button className={cx("container")} onClick={() => { setOpen(true); }}>
+        <Image src="/images/filter.svg" width={11} height={11} alt="필터" />
+        <span className={cx("text")}>필터</span>
+      </button>
+      <Modal type={MODAL_TYPE.FORM} open={open} onClose={() => { setOpen(false); }}>
+        <div style={{ position: "relative" }}>
+          <FilterForm onSubmit={() => { setOpen(false); }} />
+          <button
+            className={cx("closeBtn")}
+            onClick={() => { setOpen(false); }}
+          >
+            <Image src="/images/close.svg" fill alt="모달창 닫기" />
+          </button>
+        </div>
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/common/Filter/FilterForm/FilterForm.module.scss
+++ b/src/components/common/Filter/FilterForm/FilterForm.module.scss
@@ -37,7 +37,7 @@
           height: 40px;
           padding: 15px 13px;
           border-radius: 6px;
-          background: $sub-color1;
+          background-color: $sub-color1;
 
           &::placeholder {
             @include typo(14);

--- a/src/components/common/Filter/FilterForm/FilterForm.module.scss
+++ b/src/components/common/Filter/FilterForm/FilterForm.module.scss
@@ -1,0 +1,94 @@
+.container {
+  @include flexbox(column);
+
+  gap: 32px;
+
+  .formHeading {
+    @include flexbox(row, space-between);
+    @include typo(16, bold);
+  }
+
+  .formBody {
+    @include flexbox(column);
+
+    gap: 18px;
+
+    .row {
+      @include flexbox(row, space-between, center);
+
+      width: 422px;
+
+      label {
+        @include typo(14);
+      }
+
+      .inputArea {
+        width: 330px;
+
+        @include flexbox(row, space-between, center);
+
+        &.commissionRate {
+          justify-content: center;
+          height: 42px;
+        }
+
+        .rangeField {
+          width: 132px;
+          height: 40px;
+          padding: 15px 13px;
+          border-radius: 6px;
+          background: $sub-color1;
+
+          &::placeholder {
+            @include typo(14);
+
+            color: $sub-color3;
+          }
+        }
+
+        .sliderContainer {
+          width: 300px;
+          margin-bottom: 10px;
+        }
+
+        span {
+          color: $primary-black;
+
+          @include typo(14);
+        }
+
+        /* 드롭다운 커스텀 스타일 적용용 */
+        div:first-child > button {
+          height: 40px;
+
+          div {
+            height: 40px;
+          }
+
+          img {
+            top: 50%;
+            transform: translateY(-50%);
+          }
+
+          /* 드롭다운 리스트 커스텀 스타일 */
+          & ~ div {
+            position: absolute;
+            z-index: 7;
+            left: 0;
+            width: 100%;
+          }
+        }
+      }
+    }
+
+    .hr {
+      width: 440px;
+      height: 1px;
+      background-color: $sub-color1;
+    }
+  }
+
+  .formFooter {
+    @include flexbox(row, flex-end);
+  }
+}

--- a/src/components/common/Filter/FilterForm/FilterForm.tsx
+++ b/src/components/common/Filter/FilterForm/FilterForm.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import classNames from "classnames/bind";
+
+import useArtistList from "@/services/queries/artists/useArtistList";
+
+import Button from "../../CommonBtns/Button/Button";
+import Dropdown from "../../Dropdown/Dropdown";
+import Spacing from "../../Layouts/Spacing";
+
+import styles from "./FilterForm.module.scss";
+import MultiRangeSlider from "./MultiRangeSlider";
+
+const cx = classNames.bind(styles);
+
+const FilterForm = () => {
+  const artistList = useArtistList();
+  return (
+    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); }}>
+      <h2 className={cx("formHeading")}>
+        필터
+      </h2>
+      <div className={cx("formBody")}>
+        <div className={cx("row")}>
+          <label htmlFor="memberId">
+            <input type="hidden" name="memberId" />
+            아티스트명
+          </label>
+          <div className={cx("inputArea")}>
+            <Dropdown
+              hasSearchBar
+              dropdownListData={artistList}
+              onClick={() => {}}
+            />
+          </div>
+        </div>
+        <div className={cx("row")}>
+          <label>매출액</label>
+          <div className={cx("inputArea")}>
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <span>원 ~</span>
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <span>원</span>
+          </div>
+        </div>
+        <div className={cx("row")}>
+          <label>회사이익</label>
+          <div className={cx("inputArea")}>
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <span>원 ~</span>
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <span>원</span>
+          </div>
+        </div>
+        <div className={cx("row")}>
+          <label>정산액</label>
+          <div className={cx("inputArea")}>
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <span>원 ~</span>
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <span>원</span>
+          </div>
+        </div>
+        <div className={cx("row")}>
+          <label>요율</label>
+          <div className={cx("inputArea", "commissionRate")}>
+            <div className={cx("sliderContainer")}>
+              <MultiRangeSlider min={0} max={100} />
+            </div>
+          </div>
+        </div>
+        <Spacing size={11} />
+        <div className={cx("hr")} />
+      </div>
+      <div className={cx("formFooter")}>
+        <Button theme="dark" size="small" type="submit">적용</Button>
+      </div>
+    </form>
+  );
+};
+
+export default FilterForm;

--- a/src/components/common/Filter/FilterForm/FilterForm.tsx
+++ b/src/components/common/Filter/FilterForm/FilterForm.tsx
@@ -11,7 +11,22 @@ import styles from "./FilterForm.module.scss";
 import MultiRangeSlider from "./MultiRangeSlider";
 
 const cx = classNames.bind(styles);
-
+/**
+ * 검색 필터 폼 컴포넌트
+ * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param onSubmit {Function} 폼을 제출한 후에 할 작업을 실행하는 콜백함수입니다. 폼을 제출하는 함수가 아님에 주의하세요.
+ * @example
+ * ```
+ * const [open, isOpen] = useState(false);
+ * ...
+ * return (
+ *   <button onClick={()=>{setOpen(true)}}>필터 모달 오픈</button>
+ *   <Modal>
+ *     <FilterForm onSubmit={()=>{setOpen(false)}} /> // 폼을 제출하면 모달 닫기
+ *   </Modal>
+ * );
+ * ```
+ */
 const FilterForm = ({ onSubmit }:{ onSubmit: ()=>void }) => {
   const artistList = useArtistList();
   return (

--- a/src/components/common/Filter/FilterForm/FilterForm.tsx
+++ b/src/components/common/Filter/FilterForm/FilterForm.tsx
@@ -12,10 +12,10 @@ import MultiRangeSlider from "./MultiRangeSlider";
 
 const cx = classNames.bind(styles);
 
-const FilterForm = () => {
+const FilterForm = ({ onSubmit }:{ onSubmit: ()=>void }) => {
   const artistList = useArtistList();
   return (
-    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); }}>
+    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); onSubmit(); }}>
       <h2 className={cx("formHeading")}>
         필터
       </h2>

--- a/src/components/common/Filter/FilterForm/MultiRangeSlider.module.scss
+++ b/src/components/common/Filter/FilterForm/MultiRangeSlider.module.scss
@@ -1,0 +1,87 @@
+.container {
+  position: relative;
+  width: 100%;
+
+  .slider {
+    position: relative;
+    width: 100%;
+
+    .track,
+    .range,
+    .leftVal,
+    .rightVal {
+      position: absolute;
+    }
+
+    .track,
+    .range {
+      height: 7px;
+      border-radius: 3.5px;
+    }
+
+    .track {
+      z-index: 1;
+      width: 100%;
+      background-color: $sub-color2;
+    }
+
+    .range {
+      z-index: 2;
+      background-color: $point-color-blue3;
+    }
+
+    .leftVal,
+    .rightVal {
+      @include typo(12);
+
+      margin-top: 20px;
+      transform: translateX(-50%);
+      color: $primary-black;
+    }
+  }
+
+  .thumb {
+    appearance: none;
+    position: absolute;
+    width: 100%;
+    height: 0;
+    outline: none;
+    pointer-events: none;
+
+    &::-moz-range-thumb {
+      appearance: none;
+      position: relative;
+      width: 18px;
+      height: 18px;
+      margin-top: 4px;
+      border: none;
+      border-radius: 50%;
+      background-color: $primary-white;
+      box-shadow: 0 1px 4px rgb(0 0 0 / 16%);
+      cursor: pointer;
+      pointer-events: all;
+    }
+
+    &::-webkit-slider-thumb {
+      appearance: none;
+      position: relative;
+      width: 18px;
+      height: 18px;
+      margin-top: 4px;
+      border: none;
+      border-radius: 50%;
+      background-color: $primary-white;
+      box-shadow: 0 1px 4px rgb(0 0 0 / 16%);
+      cursor: pointer;
+      pointer-events: all;
+    }
+
+    &.left {
+      z-index: 3;
+    }
+
+    &.right {
+      z-index: 4;
+    }
+  }
+}

--- a/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
+++ b/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
@@ -1,0 +1,102 @@
+import React, {
+  ChangeEvent, useCallback, useEffect, useState, useRef,
+} from "react";
+
+import classNames from "classnames/bind";
+
+import styles from "./MultiRangeSlider.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface MultiRangeSliderProps {
+  min: number;
+  max: number;
+}
+
+const MultiRangeSlider = ({ min, max }: MultiRangeSliderProps) => {
+  const [minVal, setMinVal] = useState(min);
+  const [maxVal, setMaxVal] = useState(max);
+  const minValRef = useRef(min);
+  const maxValRef = useRef(max);
+  const range = useRef<HTMLDivElement>(null);
+  const leftValRef = useRef<HTMLDivElement>(null);
+  const rightValRef = useRef<HTMLDivElement>(null);
+
+  const getPercent = useCallback((value: number) => {
+    return Math.round(((value - min) / (max - min)) * 100);
+  }, [min, max]);
+
+  // 왼쪽 thumb 움직일 때 range 너비 조정
+  useEffect(() => {
+    const minPercent = getPercent(minVal);
+    const maxPercent = getPercent(maxValRef.current);
+    const distance = maxPercent - minPercent;
+
+    if (range.current) {
+      range.current.style.left = `${minPercent}%`;
+      range.current.style.width = `${maxPercent - minPercent}%`;
+    }
+
+    if (leftValRef.current) {
+      leftValRef.current.style.left = `${minPercent}%`;
+    }
+
+    if (rightValRef.current) {
+      rightValRef.current.style.marginTop = distance < 10 ? "-20px" : "20px";
+    }
+  }, [minVal, getPercent]);
+
+  // 오른쪽 thumb 움직일 때 range 너비 조정
+  useEffect(() => {
+    const minPercent = getPercent(minValRef.current);
+    const maxPercent = getPercent(maxVal);
+    const distance = maxPercent - minPercent;
+
+    if (range.current) {
+      range.current.style.width = `${maxPercent - minPercent}%`;
+    }
+
+    if (rightValRef.current) {
+      rightValRef.current.style.left = `${maxPercent}%`;
+      rightValRef.current.style.marginTop = distance < 10 ? "-20px" : "20px";
+    }
+  }, [maxVal, getPercent]);
+
+  return (
+    <div className={cx("container")}>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={minVal}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          const value = Math.min(Number(e.target.value), maxVal - 1);
+          setMinVal(value);
+          minValRef.current = value;
+        }}
+        className={cx("thumb", "left")}
+        style={{ zIndex: minVal > max - 100 ? "5" : "3" }}
+      />
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={maxVal}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          const value = Math.max(Number(e.target.value), minVal + 1);
+          setMaxVal(value);
+          maxValRef.current = value;
+        }}
+        className={cx("thumb", "right")}
+      />
+      <div className={cx("slider")}>
+        <div className={cx("track")} />
+        <div ref={range} className={cx("range")} />
+        <div ref={leftValRef} className={cx("leftVal")}>{`${minVal}%`}</div>
+        <div ref={rightValRef} className={cx("rightVal")}>{`${maxVal}%`}</div>
+      </div>
+    </div>
+  );
+};
+
+export default MultiRangeSlider;

--- a/src/components/common/Inputs/TextField.module.scss
+++ b/src/components/common/Inputs/TextField.module.scss
@@ -1,5 +1,3 @@
-@import "https://db.onlinewebfonts.com/c/51b459eae74df5b00ba922028ccb20be?family=Password";
-
 .container {
 	position: relative;
 	width: 100%;
@@ -39,17 +37,6 @@
 
 		&::placeholder {
 			color: $sub-color3;
-		}
-
-		&[type="password"] {
-			/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-			font-family: Password;
-			letter-spacing: 5px;
-
-			&::placeholder {
-				font-family: initial;
-				letter-spacing: normal;
-			}
 		}
 	}
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -54,6 +54,18 @@ button {
   font-size: inherit;
 }
 
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type="number"] {
+  appearance: textfield;
+}
+
 a,
 button {
   -webkit-tap-highlight-color: rgb(0 0 0 / 0%);

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,3 +1,17 @@
+@font-face {
+  font-family: Password;
+  font-style: normal;
+  font-weight: normal;
+  src: url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.eot");
+  src:
+    url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.eot?#iefix") format("embedded-opentype"),
+    url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.woff") format("woff"),
+    url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.woff2") format("woff2"),
+    url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.ttf") format("truetype"),
+    url("https://db.onlinewebfonts.com/t/51b459eae74df5b00ba922028ccb20be.svg#Password") format("svg");
+  font-display: swap;
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -64,6 +78,17 @@ input::-webkit-inner-spin-button {
 /* Firefox */
 input[type="number"] {
   appearance: textfield;
+}
+
+input[type="password"] {
+  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+  font-family: Password;
+  letter-spacing: 5px;
+
+  &::placeholder {
+    font-family: initial;
+    letter-spacing: normal;
+  }
 }
 
 a,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- dev환경에서는 잘 반영되는 패스워드란 폰트(Password라는 폰트입니다)가 프로덕션 환경에서도 반영되도록 조치했습니다.
### How it Works
<!-- 간단한 로직 설명 -->
- 어떤 이유인지는 정확히 파악이 되지 않지만 `TextField` 컴포넌트의 scss파일에서 Password 폰트를 `import`하던 기존 코드는 dev환경에서만 해당 폰트가 로드되고 프로덕션 환경에서는 로드되지 않던 현상이 있었으나, 폰트를 cdn에서 import하는 부분을 `globals.scss` 파일에서 `font-face`를 이용해 가져오고, `password`타입인 `input`에 대해서 전역 스타일링을 줬더니 프로덕션 환경에서도 잘 반영되는 것을 확인했습니다. 
- 아래는 비교샷입니다. 

<caption>수정 전</caption>

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/0920aa35-37ae-4b70-b78a-2444d8e081f6)

<caption>수정 후</caption>

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/45449387/e0ae6de9-7187-48bc-a504-a4d5d0350b5a)


### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
