### PR TITLE
BPS-351/타 계정 관리 기능 추가

### DIFF
--- a/src/components/manage-accounts/AdminAccountsTable/AdminAccountsTable.tsx
+++ b/src/components/manage-accounts/AdminAccountsTable/AdminAccountsTable.tsx
@@ -1,5 +1,5 @@
 import {
-  useCallback, useEffect, useMemo, useState,
+  useCallback, useEffect, useId, useMemo, useState,
 } from "react";
 
 import classNames from "classnames/bind";
@@ -13,10 +13,10 @@ import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import useAlertModal from "@/hooks/useAlertModal";
 import useToast from "@/hooks/useToast";
+import useReissuePassword from "@/services/queries/auth/useReissuePassword";
 import useWithdrawMember from "@/services/queries/manage-accounts/useWithdrawMember";
 import { IAdminAccount } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
-import { generateRandomStringWithRegex } from "@/utils/generateRandomStringWithRegex";
 
 import ReissuedPasswordModal from "../PasswordReissueModal/ReissuedPasswordModal";
 
@@ -40,19 +40,23 @@ const AdminAccountsTable = ({ accounts, paginationElement }: AdminAccountsTableP
   const [isOpenReissuedPwModal, setIsOpenReissuedPwModal] = useState(false);
   const [newPassword, setNewPassword] = useState<string>();
   const { mutate: deleteAccount } = useWithdrawMember();
+  const { mutateAsync: reissuePassword } = useReissuePassword();
   const { showToast } = useToast();
+  const reissueModalId = useId();
   const handleDeleteAccount = useCallback((memberId: number, name: string) => {
     deleteAccount({ memberId, name });
     setFocusedAccount(undefined);
   }, [deleteAccount]);
 
-  const handleReissuePassword = useCallback((memberId: number, name: string) => {
-    setNewPassword(generateRandomStringWithRegex(/^[a-zA-Z0-9@$!%*?&_-]*$/, 6, 18));
-    // TODO: 계정 pw 변경 api 달기
-    showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`);
+  const handleReissuePassword = useCallback(async (memberId: number, name: string) => {
+    const data = await reissuePassword({ memberId });
+    if (data) {
+      setNewPassword(data.newPassword);
+      setIsOpenReissuedPwModal(true);
+      showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`, reissueModalId);
+    }
     setFocusedAccount(undefined);
-    setIsOpenReissuedPwModal(true);
-  }, [showToast]);
+  }, [reissuePassword, showToast, reissueModalId]);
 
   const deleteAlertModalProps = useMemo(() => {
     return {
@@ -73,8 +77,8 @@ const AdminAccountsTable = ({ accounts, paginationElement }: AdminAccountsTableP
       title: "비밀번호 재발급",
       message: `“${focusedAccount?.nickName}” 계정의 비밀번호를 재발급 하시겠습니까?`,
       onClose: () => { setFocusedAccount(undefined); },
-      onClickProceed: () => {
-        handleReissuePassword(focusedAccount!.memberId, focusedAccount!.nickName);
+      onClickProceed: async () => {
+        await handleReissuePassword(focusedAccount!.memberId, focusedAccount!.nickName);
       },
       proceedBtnText: "네",
       closeBtnText: "아니요",
@@ -150,6 +154,7 @@ const AdminAccountsTable = ({ accounts, paginationElement }: AdminAccountsTableP
       </TableContainerUI>
       <ReissuedPasswordModal
         newPassword={newPassword!}
+        id={reissueModalId}
         open={isOpenReissuedPwModal}
         onClose={() => { setIsOpenReissuedPwModal(false); }}
       />

--- a/src/components/manage-accounts/AdminAccountsTable/AdminAccountsTable.tsx
+++ b/src/components/manage-accounts/AdminAccountsTable/AdminAccountsTable.tsx
@@ -13,6 +13,7 @@ import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import useAlertModal from "@/hooks/useAlertModal";
 import useToast from "@/hooks/useToast";
+import useWithdrawMember from "@/services/queries/manage-accounts/useWithdrawMember";
 import { IAdminAccount } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 import { generateRandomStringWithRegex } from "@/utils/generateRandomStringWithRegex";
@@ -38,18 +39,17 @@ const AdminAccountsTable = ({ accounts, paginationElement }: AdminAccountsTableP
   const [focusedAccount, setFocusedAccount] = useState<IFocusedAccount>();
   const [isOpenReissuedPwModal, setIsOpenReissuedPwModal] = useState(false);
   const [newPassword, setNewPassword] = useState<string>();
+  const { mutate: deleteAccount } = useWithdrawMember();
   const { showToast } = useToast();
-  const handleDeleteAccount = useCallback((memberId: number, nickName: string) => {
-    // TODO: 계정 delete api 달기
-    // TODO: 계정 행 삭제 useMutation
-    showToast(`“${nickName}” 계정이 삭제되었습니다.`);
+  const handleDeleteAccount = useCallback((memberId: number, name: string) => {
+    deleteAccount({ memberId, name });
     setFocusedAccount(undefined);
-  }, [showToast]);
+  }, [deleteAccount]);
 
-  const handleReissuePassword = useCallback((memberId: number, nickName: string) => {
+  const handleReissuePassword = useCallback((memberId: number, name: string) => {
     setNewPassword(generateRandomStringWithRegex(/^[a-zA-Z0-9@$!%*?&_-]*$/, 6, 18));
     // TODO: 계정 pw 변경 api 달기
-    showToast(`“${nickName}" 계정의 비밀번호가 재발급 되었습니다.`);
+    showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`);
     setFocusedAccount(undefined);
     setIsOpenReissuedPwModal(true);
   }, [showToast]);

--- a/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
+++ b/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
@@ -13,6 +13,7 @@ import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import useAlertModal from "@/hooks/useAlertModal";
 import useToast from "@/hooks/useToast";
+import useWithdrawMember from "@/services/queries/manage-accounts/useWithdrawMember";
 import { IArtistAccount } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
 import { generateRandomStringWithRegex } from "@/utils/generateRandomStringWithRegex";
@@ -39,14 +40,13 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   const [focusedAccount, setFocusedAccount] = useState<IFocusedAccount>();
   const [isOpenReissuedPwModal, setIsOpenReissuedPwModal] = useState(false);
   const [newPassword, setNewPassword] = useState<string>();
+  const { mutate: deleteAccount } = useWithdrawMember();
   const { showToast } = useToast();
 
   const handleDeleteAccount = useCallback((memberId: number, name: string) => {
-    // TODO: 계정 delete api 달기
-    // TODO: 계정 행 삭제 useMutation
-    showToast(`“${name}” 계정이 삭제되었습니다.`);
+    deleteAccount({ memberId, name });
     setFocusedAccount(undefined);
-  }, [showToast]);
+  }, [deleteAccount]);
 
   const handleReissuePassword = useCallback((memberId: number, name: string) => {
     setNewPassword(generateRandomStringWithRegex(/^[a-zA-Z0-9@$!%*?&_-]*$/, 6, 18));

--- a/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
+++ b/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
@@ -1,5 +1,5 @@
 import {
-  useState, useEffect, useMemo, useCallback,
+  useState, useEffect, useMemo, useCallback, useId,
 } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
@@ -52,6 +52,7 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   const { mutateAsync: updateAccount } = useUpdateArtistProfile();
   const { mutateAsync: reissuePassword } = useReissuePassword();
   const { showToast } = useToast();
+  const reissueModalId = useId();
   const { register, handleSubmit } = useForm<IUpdateAccountFieldValues>();
   const handleDeleteAccount = useCallback((memberId: number, name: string) => {
     deleteAccount({ memberId, name });
@@ -63,10 +64,10 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
     if (data) {
       setNewPassword(data.newPassword);
       setIsOpenReissuedPwModal(true);
-      showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`, "reissueModal");
+      showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`, reissueModalId);
     }
     setFocusedAccount(undefined);
-  }, [reissuePassword, showToast]);
+  }, [reissuePassword, showToast, reissueModalId]);
 
   const deleteAlertModalProps = useMemo(() => {
     return {
@@ -246,6 +247,7 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
       </TableContainerUI>
       <ReissuedPasswordModal
         newPassword={newPassword!}
+        id={reissueModalId}
         open={isOpenReissuedPwModal}
         onClose={() => { setIsOpenReissuedPwModal(false); }}
       />

--- a/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
+++ b/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
@@ -14,6 +14,7 @@ import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import useAlertModal from "@/hooks/useAlertModal";
 import useToast from "@/hooks/useToast";
+import useUpdateArtistProfile from "@/services/queries/manage-accounts/useUpdateArtistProfile";
 import useWithdrawMember from "@/services/queries/manage-accounts/useWithdrawMember";
 import { IArtistAccount } from "@/types/dto";
 import { MODAL_TYPE } from "@/types/enums/modal.enum";
@@ -48,6 +49,7 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   const [isOpenReissuedPwModal, setIsOpenReissuedPwModal] = useState(false);
   const [newPassword, setNewPassword] = useState<string>();
   const { mutate: deleteAccount } = useWithdrawMember();
+  const { mutateAsync: updateAccount } = useUpdateArtistProfile();
   const { showToast } = useToast();
   const { register, handleSubmit } = useForm<IUpdateAccountFieldValues>();
   const handleDeleteAccount = useCallback((memberId: number, name: string) => {
@@ -92,10 +94,9 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   const { showAlertModal: showReissueAlertModal } = useAlertModal();
   const { showAlertModal: showDeleteAlertModal } = useAlertModal();
 
-  const onSubmit: SubmitHandler<IUpdateAccountFieldValues> = (data) => {
+  const onSubmit: SubmitHandler<IUpdateAccountFieldValues> = async (data) => {
+    await updateAccount({ memberId: focusedAccount!.memberId, patchData: data });
     setFocusedAccount(undefined);
-    // eslint-disable-next-line no-void
-    void data;
   };
 
   useEffect(() => {

--- a/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
+++ b/src/components/manage-accounts/ArtistAccountsTable/ArtistAccountsTable.tsx
@@ -13,6 +13,7 @@ import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
 import useAlertModal from "@/hooks/useAlertModal";
+import useToast from "@/hooks/useToast";
 import useReissuePassword from "@/services/queries/auth/useReissuePassword";
 import useUpdateArtistProfile from "@/services/queries/manage-accounts/useUpdateArtistProfile";
 import useWithdrawMember from "@/services/queries/manage-accounts/useWithdrawMember";
@@ -50,7 +51,7 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   const { mutate: deleteAccount } = useWithdrawMember();
   const { mutateAsync: updateAccount } = useUpdateArtistProfile();
   const { mutateAsync: reissuePassword } = useReissuePassword();
-  // const { showToast } = useToast();
+  const { showToast } = useToast();
   const { register, handleSubmit } = useForm<IUpdateAccountFieldValues>();
   const handleDeleteAccount = useCallback((memberId: number, name: string) => {
     deleteAccount({ memberId, name });
@@ -58,13 +59,14 @@ const ArtistAccountsTable = ({ accounts, paginationElement }: ArtistAccountsTabl
   }, [deleteAccount]);
 
   const handleReissuePassword = useCallback(async (memberId: number, name: string) => {
-    const data = await reissuePassword({ name, patchData: { memberId } });
+    const data = await reissuePassword({ memberId });
     if (data) {
       setNewPassword(data.newPassword);
       setIsOpenReissuedPwModal(true);
+      showToast(`“${name}" 계정의 비밀번호가 재발급 되었습니다.`, "reissueModal");
     }
     setFocusedAccount(undefined);
-  }, [reissuePassword]);
+  }, [reissuePassword, showToast]);
 
   const deleteAlertModalProps = useMemo(() => {
     return {

--- a/src/components/manage-accounts/PasswordReissueModal/ReissuedPasswordModal.tsx
+++ b/src/components/manage-accounts/PasswordReissueModal/ReissuedPasswordModal.tsx
@@ -11,18 +11,20 @@ import styles from "./ReissuedPasswordModal.module.scss";
 const cx = classNames.bind(styles);
 
 interface ReissuedPasswordModalProps {
-  newPassword: string
+  newPassword: string;
+  id: string;
   open: boolean;
   onClose: () => void;
 }
 
 const ReissuedPasswordModal = ({
   newPassword,
+  id,
   open,
   onClose,
 }: ReissuedPasswordModalProps) => {
   return (
-    <Modal type={MODAL_TYPE.INFO} open={open} onClose={onClose} id="reissueModal">
+    <Modal type={MODAL_TYPE.INFO} open={open} onClose={onClose} id={id}>
       <div className={cx("container")}>
         <h2 className={cx("title")}>비밀번호 재발급</h2>
         <Spacing size={32} />

--- a/src/components/manage-accounts/PasswordReissueModal/ReissuedPasswordModal.tsx
+++ b/src/components/manage-accounts/PasswordReissueModal/ReissuedPasswordModal.tsx
@@ -22,7 +22,7 @@ const ReissuedPasswordModal = ({
   onClose,
 }: ReissuedPasswordModalProps) => {
   return (
-    <Modal type={MODAL_TYPE.INFO} open={open} onClose={onClose}>
+    <Modal type={MODAL_TYPE.INFO} open={open} onClose={onClose} id="reissueModal">
       <div className={cx("container")}>
         <h2 className={cx("title")}>비밀번호 재발급</h2>
         <Spacing size={32} />

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -13,9 +13,9 @@ const useToast = () => {
     dispatch(setStatus(status));
     dispatch(setShow(true));
 
-    setTimeout(() => {
-      dispatch(setShow(false));
-    }, 3000);
+    // setTimeout(() => {
+    //   dispatch(setShow(false));
+    // }, 3000);
   };
 
   return { showToast };

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -13,9 +13,9 @@ const useToast = () => {
     dispatch(setStatus(status));
     dispatch(setShow(true));
 
-    // setTimeout(() => {
-    //   dispatch(setShow(false));
-    // }, 3000);
+    setTimeout(() => {
+      dispatch(setShow(false));
+    }, 3000);
   };
 
   return { showToast };

--- a/src/services/api/requests/auth/auth.delete.api.ts
+++ b/src/services/api/requests/auth/auth.delete.api.ts
@@ -1,7 +1,8 @@
+import { IDeleteMemberResponse } from "../../types/auth";
 import { deleteRequest } from "../requests.api";
 
 /* 계정 탈퇴 */
 export const withdrawMember = async (memberId: number) => {
-  const response = await deleteRequest<string>(`/auth/members/${memberId}/withdrawal`);
+  const response = await deleteRequest<IDeleteMemberResponse>(`/auth/members/${memberId}/withdrawal`);
   return response;
 };

--- a/src/services/api/requests/auth/auth.patch.api.ts
+++ b/src/services/api/requests/auth/auth.patch.api.ts
@@ -1,4 +1,5 @@
-import { IPatchChangePasswordRequest } from "../../types/auth";
+import { IPatchChangePasswordRequest, IPatchReissuePasswordRequest } from "@/services/api/types/auth";
+
 import { patchRequest } from "../requests.api";
 
 /* 비밀번호 변경 */
@@ -9,5 +10,11 @@ export const changePassword = async ({
   const response = await patchRequest<string, IPatchChangePasswordRequest>("/auth/member/password", {
     password,
   });
+  return response;
+};
+
+/* 비밀번호 재발급 */
+export const reissuePassword = async ({ memberId }: IPatchReissuePasswordRequest) => {
+  const response = await patchRequest(`/auth/members/${memberId}/password`, {});
   return response;
 };

--- a/src/services/api/requests/auth/auth.patch.api.ts
+++ b/src/services/api/requests/auth/auth.patch.api.ts
@@ -1,4 +1,4 @@
-import { IPatchChangePasswordRequest, IPatchReissuePasswordRequest } from "@/services/api/types/auth";
+import { IPatchChangePasswordRequest, IPatchReissuePasswordRequest, IPatchReissuePasswordResponse } from "@/services/api/types/auth";
 
 import { patchRequest } from "../requests.api";
 
@@ -15,6 +15,6 @@ export const changePassword = async ({
 
 /* 비밀번호 재발급 */
 export const reissuePassword = async ({ memberId }: IPatchReissuePasswordRequest) => {
-  const response = await patchRequest(`/auth/members/${memberId}/password`, {});
+  const response = await patchRequest<IPatchReissuePasswordResponse, unknown>(`/auth/members/${memberId}/password`, {});
   return response;
 };

--- a/src/services/api/types/auth.ts
+++ b/src/services/api/types/auth.ts
@@ -61,6 +61,10 @@ export interface IPostArtistSignInResponse {
 export interface IPostAdminSignUpResponse extends Omit<IAdminProfile, "profileImage"> {
 }
 
+export interface IPatchReissuePasswordResponse {
+  newPassword: string;
+}
+
 export interface IDeleteMemberResponse {
   memberId: number;
 }

--- a/src/services/api/types/auth.ts
+++ b/src/services/api/types/auth.ts
@@ -1,4 +1,6 @@
-import { IAdminProfile, IAdminSignup, ISignIn } from "@/types/dto";
+import {
+  IAdminProfile, IAdminSignup, IProfile, ISignIn,
+} from "@/types/dto";
 import {
   AdminRole, AdminType, ArtistRole, UserType,
 } from "@/types/enums/user.enum";
@@ -13,6 +15,9 @@ export interface IPostArtistSignInRequest extends ISignIn {
 }
 
 export interface IPatchChangePasswordRequest extends Pick<ISignIn, "password"> {
+}
+
+export interface IPatchReissuePasswordRequest extends Pick<IProfile, "memberId"> {
 }
 
 export interface IPostConfirmPasswordRequest extends Pick<ISignIn, "password"> {

--- a/src/services/api/types/auth.ts
+++ b/src/services/api/types/auth.ts
@@ -55,3 +55,12 @@ export interface IPostArtistSignInResponse {
 
 export interface IPostAdminSignUpResponse extends Omit<IAdminProfile, "profileImage"> {
 }
+
+export interface IDeleteMemberResponse {
+  memberId: number;
+}
+
+export interface IDeleteMemberReqeust {
+  memberId: number;
+  name: string;
+}

--- a/src/services/queries/auth/useReissuePassword.ts
+++ b/src/services/queries/auth/useReissuePassword.ts
@@ -1,0 +1,42 @@
+import { useMutation } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+
+import useAlertModal from "@/hooks/useAlertModal";
+import useToast from "@/hooks/useToast";
+import { reissuePassword } from "@/services/api/requests/auth/auth.patch.api";
+import { IPatchReissuePasswordRequest, IPatchReissuePasswordResponse } from "@/services/api/types/auth";
+import { ICommonErrorResponse } from "@/services/api/types/global";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import { isCommonError } from "@/utils/type.predicates";
+
+const useReissuePassword = () => {
+  const { showToast } = useToast();
+  const { showAlertModal } = useAlertModal();
+  const mutation = useMutation<
+  IPatchReissuePasswordResponse,
+  unknown,
+  { name: string, patchData: IPatchReissuePasswordRequest },
+  unknown
+  >(
+    (data) => { return reissuePassword(data.patchData); },
+    {
+      onSuccess: (_, variables) => {
+        showToast(`“${variables.name}" 계정의 비밀번호가 재발급 되었습니다.`);
+      },
+      onError: (err) => {
+        if (isAxiosError<ICommonErrorResponse>(err)) {
+          if (isCommonError(err.response?.data)) {
+            showAlertModal({
+              type: MODAL_TYPE.ERROR,
+              title: "비밀번호 재발급 에러",
+              message: err.response?.data.message ?? "알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도하세요.",
+            });
+          }
+        } else console.error(err);
+      },
+    },
+  );
+  return mutation;
+};
+
+export default useReissuePassword;

--- a/src/services/queries/auth/useReissuePassword.ts
+++ b/src/services/queries/auth/useReissuePassword.ts
@@ -2,7 +2,6 @@ import { useMutation } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 
 import useAlertModal from "@/hooks/useAlertModal";
-import useToast from "@/hooks/useToast";
 import { reissuePassword } from "@/services/api/requests/auth/auth.patch.api";
 import { IPatchReissuePasswordRequest, IPatchReissuePasswordResponse } from "@/services/api/types/auth";
 import { ICommonErrorResponse } from "@/services/api/types/global";
@@ -10,19 +9,15 @@ import { MODAL_TYPE } from "@/types/enums/modal.enum";
 import { isCommonError } from "@/utils/type.predicates";
 
 const useReissuePassword = () => {
-  const { showToast } = useToast();
   const { showAlertModal } = useAlertModal();
   const mutation = useMutation<
   IPatchReissuePasswordResponse,
   unknown,
-  { name: string, patchData: IPatchReissuePasswordRequest },
+  IPatchReissuePasswordRequest,
   unknown
   >(
-    (data) => { return reissuePassword(data.patchData); },
+    reissuePassword,
     {
-      onSuccess: (_, variables) => {
-        showToast(`“${variables.name}" 계정의 비밀번호가 재발급 되었습니다.`);
-      },
       onError: (err) => {
         if (isAxiosError<ICommonErrorResponse>(err)) {
           if (isCommonError(err.response?.data)) {

--- a/src/services/queries/manage-accounts/useUpdateArtistProfile.ts
+++ b/src/services/queries/manage-accounts/useUpdateArtistProfile.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+
+import useAlertModal from "@/hooks/useAlertModal";
+import useToast from "@/hooks/useToast";
+import { patchArtistProfileForAdmin } from "@/services/api/requests/artist/artist.patch.api";
+import { IPatchArtistProfileForAdminRequest, IPatchArtistProfileForAdminResponse } from "@/services/api/types/artist";
+import { ICommonErrorResponse } from "@/services/api/types/global";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import { MEMBER_TYPE } from "@/types/enums/user.enum";
+import { isCommonError } from "@/utils/type.predicates";
+
+const useUpdateArtistProfile = () => {
+  const queryClient = useQueryClient();
+  const { showAlertModal } = useAlertModal();
+  const { showToast } = useToast();
+  const mutation = useMutation<
+  IPatchArtistProfileForAdminResponse,
+  unknown,
+  {
+    memberId: number,
+    patchData: IPatchArtistProfileForAdminRequest;
+  },
+  unknown>(
+    (data) => { return patchArtistProfileForAdmin(data.memberId, data.patchData); },
+    {
+      onSuccess: () => {
+        showToast("수정이 완료되었습니다.");
+        // eslint-disable-next-line no-void
+        void queryClient.refetchQueries({ queryKey: [MEMBER_TYPE.ADMIN, "manage-accounts"], type: "all" });
+      },
+      onError: (err) => {
+        if (isAxiosError<ICommonErrorResponse>(err)) {
+          if (isCommonError(err.response?.data)) {
+            showAlertModal({
+              type: MODAL_TYPE.ERROR,
+              title: "계정 수정 에러",
+              message: err.response?.data.message ?? "알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도하세요.",
+            });
+          }
+        } else console.error(err);
+      },
+    },
+  );
+
+  return mutation;
+};
+
+export default useUpdateArtistProfile;

--- a/src/services/queries/manage-accounts/useWithdrawMember.ts
+++ b/src/services/queries/manage-accounts/useWithdrawMember.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+
+import useAlertModal from "@/hooks/useAlertModal";
+import useToast from "@/hooks/useToast";
+import { withdrawMember } from "@/services/api/requests/auth/auth.delete.api";
+import { IDeleteMemberReqeust, IDeleteMemberResponse } from "@/services/api/types/auth";
+import { ICommonErrorResponse } from "@/services/api/types/global";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
+import { MEMBER_TYPE } from "@/types/enums/user.enum";
+import { isCommonError } from "@/utils/type.predicates";
+
+const useWithdrawMember = () => {
+  const queryClient = useQueryClient();
+  const { showAlertModal } = useAlertModal();
+  const { showToast } = useToast();
+  const mutation = useMutation<
+  IDeleteMemberResponse,
+  unknown,
+  IDeleteMemberReqeust,
+  unknown>((data) => {
+    return withdrawMember(data.memberId);
+  }, {
+    onSuccess: (_, variables) => {
+      showToast(`“${variables.name}” 계정이 삭제되었습니다.`);
+      // eslint-disable-next-line no-void
+      void queryClient.refetchQueries({ queryKey: [MEMBER_TYPE.ADMIN, "manage-accounts"], type: "all" });
+    },
+    onError: (err) => {
+      if (isAxiosError<ICommonErrorResponse>(err)) {
+        if (isCommonError(err.response?.data)) {
+          showAlertModal({
+            type: MODAL_TYPE.ERROR,
+            title: "계정 탈퇴 에러",
+            message: err.response?.data.message ?? "알 수 없는 에러가 발생했습니다. 잠시 후에 다시 시도하세요.",
+          });
+        }
+      } else console.error(err);
+    },
+  });
+
+  return mutation;
+};
+
+export default useWithdrawMember;

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -145,7 +145,7 @@ export interface IArtistList {
 }
 
 // 프로필 관련
-interface IProfile {
+export interface IProfile {
   memberId: number,
   loginId: string,
   profileImage: string | null


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 어드민, 수퍼 어드민의 manage-accounts 페이지의 아티스트 계정, 어드민 계정 관리 기능을 추가했습니다.
- 아티스트 정보 수정(예명, 요율)기능을 추가했습니다.
- 아티스트 계정과 어드민 계정의 비밀번호 재발급, 계정 탈퇴 기능을 추가했습니다.

### How it Works
<!-- 간단한 로직 설명 -->
- 필요한 api요청 함수를 만들거나 수정하고, 각 요청에 대응하는 뮤테이션 훅을 만들고 퍼블리싱된 버튼들에 mutate함수와 바인딩하여 구현했습니다.

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
