### PR TITLE
BPS-376/정렬, 필터 기능 구현

### DIFF
--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -8,6 +8,7 @@ interface DropdownProps<T> {
   theme?: "bright" | "dark" | "withSearchBar";
   hasSearchBar?: boolean;
   onClick: (value: T) => void;
+  initialValue?: T
 }
 /**
  * @author 임병욱
@@ -19,14 +20,15 @@ interface DropdownProps<T> {
  * @param theme "withSearchBar"는 검색창과 같이 사용할 경우, radius가 적용되지않고 드롭다운의 오른쪽 모서리가 직각이 되는 스타일이 적용됩니다.
  * @param hasSearchBar 드롭다운 리스트에 검색창이 필요하다면 이 속성을 true로 설정해주세요.
  * @param onClick 드롭다운에 클릭된 값을 알기위해 event.currentTarget.value를 받는 함수를 넣어주면 됩니다.
+ * @param initialValue 드롭다운에 들어갈 초기값입니다. 값을 설정하지 않으면 dropdownListData[0]이 설정됩니다.
 */
 const Dropdown = <T extends string | IHasSearchBarData>({
-  dropdownListData, theme = "bright", hasSearchBar = false, onClick,
+  dropdownListData, theme = "bright", hasSearchBar = false, onClick, initialValue,
 }: DropdownProps<T>) => {
   const [toggle, setToggle] = useState<boolean>(false);
   const dropdownContainerRef = useRef<HTMLDivElement>(null);
 
-  const initialSelectedDropdownValue = hasSearchBar ? "대표 아티스트를 지정해주세요." : dropdownListData[0];
+  const initialSelectedDropdownValue = hasSearchBar ? "대표 아티스트를 지정해주세요." : initialValue ?? dropdownListData[0];
 
   // eslint-disable-next-line max-len
   const [selectedDropdownValue, setSelectedDropdownValue] = useState<string | IHasSearchBarData>(initialSelectedDropdownValue);

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -28,7 +28,7 @@ const Dropdown = <T extends string | IHasSearchBarData>({
   const [toggle, setToggle] = useState<boolean>(false);
   const dropdownContainerRef = useRef<HTMLDivElement>(null);
 
-  const initialSelectedDropdownValue = hasSearchBar ? "대표 아티스트를 지정해주세요." : initialValue ?? dropdownListData[0];
+  const initialSelectedDropdownValue = initialValue ?? (hasSearchBar ? "대표 아티스트를 지정해주세요." : dropdownListData[0]);
 
   // eslint-disable-next-line max-len
   const [selectedDropdownValue, setSelectedDropdownValue] = useState<string | IHasSearchBarData>(initialSelectedDropdownValue);
@@ -77,6 +77,10 @@ const Dropdown = <T extends string | IHasSearchBarData>({
       document.removeEventListener("click", handleClick);
     };
   });
+
+  useEffect(() => {
+    setSelectedDropdownValue(initialSelectedDropdownValue);
+  }, [initialSelectedDropdownValue]);
 
   return (
     <DropdownUI

--- a/src/components/common/Filter/Filter.tsx
+++ b/src/components/common/Filter/Filter.tsx
@@ -9,10 +9,11 @@ import { MODAL_TYPE } from "@/types/enums/modal.enum";
 import Modal from "../Modals/Modal";
 
 import styles from "./Filter.module.scss";
+import { IFilterOptions } from "./Filter.type";
 
 const cx = classNames.bind(styles);
 
-const Filter = () => {
+const Filter = ({ onSubmit }: { onSubmit: (options: IFilterOptions) => void }) => {
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -22,7 +23,7 @@ const Filter = () => {
       </button>
       <Modal type={MODAL_TYPE.FORM} open={open} onClose={() => { setOpen(false); }}>
         <div style={{ position: "relative" }}>
-          <FilterForm onSubmitSuccess={() => { setOpen(false); }} />
+          <FilterForm onSubmit={onSubmit} onSubmitSuccess={() => { setOpen(false); }} />
           <button
             className={cx("closeBtn")}
             onClick={() => { setOpen(false); }}

--- a/src/components/common/Filter/Filter.type.ts
+++ b/src/components/common/Filter/Filter.type.ts
@@ -1,0 +1,3 @@
+export interface IFilterOptions {
+  [key: string]: string
+}

--- a/src/components/common/Filter/FilterForm/FilterForm.tsx
+++ b/src/components/common/Filter/FilterForm/FilterForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 /* eslint-disable jsx-a11y/label-has-associated-control */
-import { useState, useCallback } from "react";
+import { useState, useRef } from "react";
 
 import classNames from "classnames/bind";
 import { useRouter } from "next/router";
@@ -14,6 +14,7 @@ import { IFilterOptions } from "../Filter.type";
 
 import styles from "./FilterForm.module.scss";
 import MultiRangeSlider from "./MultiRangeSlider";
+import { ISliderRefsObj } from "./MultiRangeSlider.type";
 
 const cx = classNames.bind(styles);
 
@@ -48,61 +49,80 @@ const FilterForm = ({ onSubmit, onSubmitSuccess }: FilterFormProps) => {
   } = router.query;
   const initialOptions = {
     mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
-  };
-  const [options, setOptions] = useState(initialOptions as IFilterOptions);
+  } as IFilterOptions;
+  const [mIdValue, setMIdValue] = useState(initialOptions.mId);
+  const revFrRef = useRef<HTMLInputElement>(null);
+  const revToRef = useRef<HTMLInputElement>(null);
+  const netFrRef = useRef<HTMLInputElement>(null);
+  const netToRef = useRef<HTMLInputElement>(null);
+  const setFrRef = useRef<HTMLInputElement>(null);
+  const setToRef = useRef<HTMLInputElement>(null);
+  const comRefs = useRef<ISliderRefsObj>({
+    comFrRef: null,
+    comToRef: null,
+  });
 
-  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setOptions((prevOptions) => { return { ...prevOptions, [e.target.name]: e.target.value }; });
+  const handleSubmitFilterForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const options = {
+      mId: mIdValue,
+      revFr: revFrRef.current?.value ?? "",
+      revTo: revToRef.current?.value ?? "",
+      netFr: netFrRef.current?.value ?? "",
+      netTo: netToRef.current?.value ?? "",
+      setFr: setFrRef.current?.value ?? "",
+      setTo: setToRef.current?.value ?? "",
+      comFr: comRefs.current.comFrRef?.value ?? "",
+      comTo: comRefs.current.comToRef?.value ?? "",
+    };
+    onSubmit(options);
+    onSubmitSuccess();
   };
-
-  const handleChangeComRatioRange = useCallback((min: number, max: number) => {
-    setOptions((prevOptions) => { return { ...prevOptions, comFr: String(min), comTo: String(max) }; });
-  }, []);
 
   return (
-    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); onSubmit(options); onSubmitSuccess(); }}>
+    <form className={cx("container")} onSubmit={handleSubmitFilterForm}>
       <h2 className={cx("formHeading")}>
         필터
       </h2>
       <div className={cx("formBody")}>
         <div className={cx("row")}>
           <label htmlFor="memberId">
-            <input type="hidden" name="memberId" />
+            <input type="hidden" name="memberId" value={mIdValue} />
             아티스트명
           </label>
           <div className={cx("inputArea")}>
             <Dropdown
               hasSearchBar
               dropdownListData={artistList}
-              onClick={(value) => { setOptions((prevOptions) => { return { ...prevOptions, mId: String(value.id) }; }); }}
-              initialValue={artistList.find((artist) => { return artist.id === Number(options.mId); })}
+              onClick={(value) => { return setMIdValue(String(value.id)); }}
+              initialValue={artistList.find((artist) => { return artist.id === Number(initialOptions.mId); })}
             />
           </div>
         </div>
         <div className={cx("row")}>
           <label>매출액</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="revFr" value={options.revFr} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" ref={revFrRef} defaultValue={initialOptions.revFr} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="revTo" value={options.revTo} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" ref={revToRef} defaultValue={initialOptions.revTo} />
             <span>원</span>
           </div>
         </div>
         <div className={cx("row")}>
           <label>회사이익</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="netFr" value={options.netFr} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" ref={netFrRef} defaultValue={initialOptions.netFr} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="netTo" value={options.netTo} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" ref={netToRef} defaultValue={initialOptions.netTo} />
             <span>원</span>
           </div>
         </div>
         <div className={cx("row")}>
           <label>정산액</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="setFr" value={options.setFr} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" ref={setFrRef} defaultValue={initialOptions.setFr} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="setTo" value={options.setTo} onChange={handleChangeInput} />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" ref={setToRef} defaultValue={initialOptions.setTo} />
             <span>원</span>
           </div>
         </div>
@@ -110,7 +130,7 @@ const FilterForm = ({ onSubmit, onSubmitSuccess }: FilterFormProps) => {
           <label>요율</label>
           <div className={cx("inputArea", "commissionRate")}>
             <div className={cx("sliderContainer")}>
-              <MultiRangeSlider min={0} max={100} initialMinValue={Number(options.comFr)} initialMaxValue={Number(options.comTo)} onChangeValue={handleChangeComRatioRange} />
+              <MultiRangeSlider min={0} max={100} initialMinValue={Number(initialOptions.comFr)} initialMaxValue={Number(initialOptions.comTo)} ref={comRefs} />
             </div>
           </div>
         </div>

--- a/src/components/common/Filter/FilterForm/FilterForm.tsx
+++ b/src/components/common/Filter/FilterForm/FilterForm.tsx
@@ -1,19 +1,31 @@
+/* eslint-disable max-len */
 /* eslint-disable jsx-a11y/label-has-associated-control */
+import { useState, useCallback } from "react";
+
 import classNames from "classnames/bind";
+import { useRouter } from "next/router";
 
 import useArtistList from "@/services/queries/artists/useArtistList";
 
 import Button from "../../CommonBtns/Button/Button";
 import Dropdown from "../../Dropdown/Dropdown";
 import Spacing from "../../Layouts/Spacing";
+import { IFilterOptions } from "../Filter.type";
 
 import styles from "./FilterForm.module.scss";
 import MultiRangeSlider from "./MultiRangeSlider";
 
 const cx = classNames.bind(styles);
+
+interface FilterFormProps {
+  onSubmit: (options: IFilterOptions) => void,
+  onSubmitSuccess: () => void
+}
+
 /**
  * 검색 필터 폼 컴포넌트
  * @author [SeyoungCho](https://github.com/seyoungcho)
+ * @param onSubmit {Function} 폼을 제출할 때 실행하는 콜백함수입니다.
  * @param onSubmitSuccess {Function} 폼을 제출한 후에 할 작업을 실행하는 콜백함수입니다. 폼을 제출하는 함수가 아님에 주의하세요.
  * @example
  * ```
@@ -22,15 +34,33 @@ const cx = classNames.bind(styles);
  * return (
  *   <button onClick={()=>{setOpen(true)}}>필터 모달 오픈</button>
  *   <Modal>
- *     <FilterForm onSubmit={()=>{setOpen(false)}} /> // 폼을 제출하면 모달 닫기
+ *     <FilterForm onSubmit={onSubmit} onSubmitSuccess={()=>{setOpen(false)}} />
  *   </Modal>
  * );
  * ```
  */
-const FilterForm = ({ onSubmitSuccess }:{ onSubmitSuccess: () => void }) => {
+const FilterForm = ({ onSubmit, onSubmitSuccess }: FilterFormProps) => {
   const artistList = useArtistList();
+
+  const router = useRouter();
+  const {
+    mId = "", revFr = "", revTo = "", netFr = "", netTo = "", setFr = "", setTo = "", comFr = "", comTo = "",
+  } = router.query;
+  const initialOptions = {
+    mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
+  };
+  const [options, setOptions] = useState(initialOptions as IFilterOptions);
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setOptions((prevOptions) => { return { ...prevOptions, [e.target.name]: e.target.value }; });
+  };
+
+  const handleChangeComRatioRange = useCallback((min: number, max: number) => {
+    setOptions((prevOptions) => { return { ...prevOptions, comFr: String(min), comTo: String(max) }; });
+  }, []);
+
   return (
-    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); onSubmitSuccess(); }}>
+    <form className={cx("container")} onSubmit={(e) => { e.preventDefault(); onSubmit(options); onSubmitSuccess(); }}>
       <h2 className={cx("formHeading")}>
         필터
       </h2>
@@ -44,34 +74,35 @@ const FilterForm = ({ onSubmitSuccess }:{ onSubmitSuccess: () => void }) => {
             <Dropdown
               hasSearchBar
               dropdownListData={artistList}
-              onClick={() => {}}
+              onClick={(value) => { setOptions((prevOptions) => { return { ...prevOptions, mId: String(value.id) }; }); }}
+              initialValue={artistList.find((artist) => { return artist.id === Number(options.mId); })}
             />
           </div>
         </div>
         <div className={cx("row")}>
           <label>매출액</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="revFr" value={options.revFr} onChange={handleChangeInput} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="revTo" value={options.revTo} onChange={handleChangeInput} />
             <span>원</span>
           </div>
         </div>
         <div className={cx("row")}>
           <label>회사이익</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="netFr" value={options.netFr} onChange={handleChangeInput} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="netTo" value={options.netTo} onChange={handleChangeInput} />
             <span>원</span>
           </div>
         </div>
         <div className={cx("row")}>
           <label>정산액</label>
           <div className={cx("inputArea")}>
-            <input type="number" className={cx("rangeField")} placeholder="최소 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최소 금액" name="setFr" value={options.setFr} onChange={handleChangeInput} />
             <span>원 ~</span>
-            <input type="number" className={cx("rangeField")} placeholder="최대 금액" />
+            <input type="number" className={cx("rangeField")} placeholder="최대 금액" name="setTo" value={options.setTo} onChange={handleChangeInput} />
             <span>원</span>
           </div>
         </div>
@@ -79,7 +110,7 @@ const FilterForm = ({ onSubmitSuccess }:{ onSubmitSuccess: () => void }) => {
           <label>요율</label>
           <div className={cx("inputArea", "commissionRate")}>
             <div className={cx("sliderContainer")}>
-              <MultiRangeSlider min={0} max={100} />
+              <MultiRangeSlider min={0} max={100} initialMinValue={Number(options.comFr)} initialMaxValue={Number(options.comTo)} onChangeValue={handleChangeComRatioRange} />
             </div>
           </div>
         </div>

--- a/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
+++ b/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
@@ -12,21 +12,25 @@ const cx = classNames.bind(styles);
 interface MultiRangeSliderProps {
   min: number;
   max: number;
+  initialMinValue?: number;
+  initialMaxValue?: number;
+  onChangeValue: (min: number, max: number) => void;
 }
 
-const MultiRangeSlider = ({ min, max }: MultiRangeSliderProps) => {
-  const [minVal, setMinVal] = useState(min);
-  const [maxVal, setMaxVal] = useState(max);
+const MultiRangeSlider = ({
+  min, max, initialMinValue, initialMaxValue, onChangeValue,
+}: MultiRangeSliderProps) => {
+  const [minVal, setMinVal] = useState(initialMinValue || min);
+  const [maxVal, setMaxVal] = useState(initialMaxValue || max);
   const minValRef = useRef(min);
   const maxValRef = useRef(max);
   const range = useRef<HTMLDivElement>(null);
   const leftValRef = useRef<HTMLDivElement>(null);
   const rightValRef = useRef<HTMLDivElement>(null);
 
-  // 왼쪽 thumb 움직일 때 range 너비 조정
   useEffect(() => {
     const minPercent = getPercent(minVal, min, max);
-    const maxPercent = getPercent(maxValRef.current, min, max);
+    const maxPercent = getPercent(maxVal, min, max);
     const distance = maxPercent - minPercent;
 
     if (range.current) {
@@ -39,25 +43,14 @@ const MultiRangeSlider = ({ min, max }: MultiRangeSliderProps) => {
     }
 
     if (rightValRef.current) {
-      rightValRef.current.style.marginTop = distance < 10 ? "-20px" : "20px";
-    }
-  }, [minVal, min, max]);
-
-  // 오른쪽 thumb 움직일 때 range 너비 조정
-  useEffect(() => {
-    const minPercent = getPercent(minValRef.current, min, max);
-    const maxPercent = getPercent(maxVal, min, max);
-    const distance = maxPercent - minPercent;
-
-    if (range.current) {
-      range.current.style.width = `${maxPercent - minPercent}%`;
-    }
-
-    if (rightValRef.current) {
       rightValRef.current.style.left = `${maxPercent}%`;
       rightValRef.current.style.marginTop = distance < 10 ? "-20px" : "20px";
     }
-  }, [maxVal, min, max]);
+  }, [minVal, maxVal, min, max]);
+
+  useEffect(() => {
+    onChangeValue(minVal, maxVal);
+  }, [minVal, maxVal, onChangeValue]);
 
   return (
     <div className={cx("container")}>

--- a/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
+++ b/src/components/common/Filter/FilterForm/MultiRangeSlider.tsx
@@ -5,6 +5,7 @@ import React, {
 import classNames from "classnames/bind";
 
 import styles from "./MultiRangeSlider.module.scss";
+import { ISliderRefsObj } from "./MultiRangeSlider.type";
 import { getPercent } from "./MultiRangeSlider.util";
 
 const cx = classNames.bind(styles);
@@ -14,16 +15,17 @@ interface MultiRangeSliderProps {
   max: number;
   initialMinValue?: number;
   initialMaxValue?: number;
-  onChangeValue: (min: number, max: number) => void;
 }
 
-const MultiRangeSlider = ({
-  min, max, initialMinValue, initialMaxValue, onChangeValue,
-}: MultiRangeSliderProps) => {
+const MultiRangeSlider = (
+  {
+    min, max, initialMinValue, initialMaxValue,
+  }: MultiRangeSliderProps,
+  ref: React.ForwardedRef<ISliderRefsObj>,
+) => {
   const [minVal, setMinVal] = useState(initialMinValue || min);
   const [maxVal, setMaxVal] = useState(initialMaxValue || max);
-  const minValRef = useRef(min);
-  const maxValRef = useRef(max);
+  const { current } = ref as React.MutableRefObject<ISliderRefsObj>;
   const range = useRef<HTMLDivElement>(null);
   const leftValRef = useRef<HTMLDivElement>(null);
   const rightValRef = useRef<HTMLDivElement>(null);
@@ -48,10 +50,6 @@ const MultiRangeSlider = ({
     }
   }, [minVal, maxVal, min, max]);
 
-  useEffect(() => {
-    onChangeValue(minVal, maxVal);
-  }, [minVal, maxVal, onChangeValue]);
-
   return (
     <div className={cx("container")}>
       <input
@@ -62,10 +60,12 @@ const MultiRangeSlider = ({
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           const value = Math.min(Number(e.target.value), maxVal - 1);
           setMinVal(value);
-          minValRef.current = value;
         }}
         className={cx("thumb", "left")}
         style={{ zIndex: minVal > max - 100 ? "5" : "3" }}
+        ref={(el) => {
+          current.comFrRef = el;
+        }}
       />
       <input
         type="range"
@@ -75,9 +75,11 @@ const MultiRangeSlider = ({
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           const value = Math.max(Number(e.target.value), minVal + 1);
           setMaxVal(value);
-          maxValRef.current = value;
         }}
         className={cx("thumb", "right")}
+        ref={(el) => {
+          current.comToRef = el;
+        }}
       />
       <div className={cx("slider")}>
         <div className={cx("track")} />
@@ -89,4 +91,4 @@ const MultiRangeSlider = ({
   );
 };
 
-export default MultiRangeSlider;
+export default React.forwardRef<ISliderRefsObj, MultiRangeSliderProps>(MultiRangeSlider);

--- a/src/components/common/Filter/FilterForm/MultiRangeSlider.type.ts
+++ b/src/components/common/Filter/FilterForm/MultiRangeSlider.type.ts
@@ -1,0 +1,4 @@
+export interface ISliderRefsObj {
+  comFrRef: HTMLInputElement | null,
+  comToRef: HTMLInputElement | null
+}

--- a/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
@@ -51,6 +51,8 @@ const AdminTrackStatusTable = ({
       router.query,
       "sortBy",
       REVERSE_SORT_BY_OPTIONS_MAP[value],
+      "page",
+      1,
     ), undefined, { scroll: false });
   };
 
@@ -66,6 +68,8 @@ const AdminTrackStatusTable = ({
       REVERSE_SEARCH_BY_OPTIONS_MAP[searchByValue],
       "keyword",
       searchBarRef.current?.value ?? "",
+      "page",
+      1,
     ), undefined, { scroll: false });
   };
 

--- a/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useState, useRef } from "react";
 
 import classNames from "classnames/bind";
@@ -17,7 +16,9 @@ import TableContainerUI from "@/components/common/Table/Composition/TableContain
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
-import { REVERSE_SEARCH_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP } from "@/constants/trackStatusTable";
+import {
+  REVERSE_SEARCH_BY_OPTIONS_MAP, REVERSE_SORT_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP, SORT_BY_OPTIONS_MAP,
+} from "@/constants/trackStatusTable";
 import { ITrackTransaction } from "@/types/dto";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 import formatMoney from "@/utils/formatMoney";
@@ -35,17 +36,22 @@ interface AdminTrackStatusTableProps {
   isEmpty?: boolean
   paginationElement?: React.ReactNode
   searchBy: string
+  sortBy: string
 }
 
 const AdminTrackStatusTable = ({
-  title, data, isEmpty = false, paginationElement, searchBy,
+  title, data, isEmpty = false, paginationElement, searchBy, sortBy,
 }: AdminTrackStatusTableProps) => {
   const router = useRouter();
   const [searchByValue, setSearchByValue] = useState(SEARCH_BY_OPTIONS_MAP[searchBy] ?? "곡 명");
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   const handleClickSortByDropdown = (value: string) => {
-    // TODO: 정렬 순서 쿼리 파람 변경
+    router.push(updateQueryParam(
+      router.query,
+      "sortBy",
+      REVERSE_SORT_BY_OPTIONS_MAP[value],
+    ), undefined, { scroll: false });
   };
 
   const handleClickSearchByDropdown = (value: string) => {
@@ -69,7 +75,8 @@ const AdminTrackStatusTable = ({
         <h2 className={cx("title")}>{title}</h2>
         <div className={cx("utilContainer")}>
           <Dropdown
-            dropdownListData={["매출순", "회사 이익순", "정산액순", "요율순"]}
+            dropdownListData={Object.values(SORT_BY_OPTIONS_MAP)}
+            initialValue={SORT_BY_OPTIONS_MAP[sortBy] ?? "매출순"}
             onClick={handleClickSortByDropdown}
           />
           <Spacing direction="horizontal" size={18} />

--- a/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
@@ -17,6 +17,7 @@ import TableContainerUI from "@/components/common/Table/Composition/TableContain
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
+import { REVERSE_SEARCH_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP } from "@/constants/trackStatusTable";
 import { ITrackTransaction } from "@/types/dto";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 import formatMoney from "@/utils/formatMoney";
@@ -33,13 +34,14 @@ interface AdminTrackStatusTableProps {
   data: ITrackTransaction[]
   isEmpty?: boolean
   paginationElement?: React.ReactNode
+  searchBy: string
 }
 
 const AdminTrackStatusTable = ({
-  title, data, isEmpty = false, paginationElement,
+  title, data, isEmpty = false, paginationElement, searchBy,
 }: AdminTrackStatusTableProps) => {
   const router = useRouter();
-  const [selectedValue, setSelectedValue] = useState(router.query?.searchBy === "albumName" ? "albumName" : "trackName");
+  const [searchByValue, setSearchByValue] = useState(SEARCH_BY_OPTIONS_MAP[searchBy] ?? "곡 명");
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   const handleClickSortByDropdown = (value: string) => {
@@ -47,7 +49,7 @@ const AdminTrackStatusTable = ({
   };
 
   const handleClickSearchByDropdown = (value: string) => {
-    setSelectedValue(value === "곡 명" ? "trackName" : "albumName");
+    setSearchByValue(value);
   };
 
   const handleClickSearchBar = (event: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>) => {
@@ -55,7 +57,7 @@ const AdminTrackStatusTable = ({
     router.push(updateQueryParam(
       router.query,
       "searchBy",
-      selectedValue,
+      REVERSE_SEARCH_BY_OPTIONS_MAP[searchByValue],
       "keyword",
       searchBarRef.current?.value ?? "",
     ), undefined, { scroll: false });
@@ -74,7 +76,8 @@ const AdminTrackStatusTable = ({
           <Filter />
           <Spacing direction="horizontal" size={32} />
           <Dropdown
-            dropdownListData={selectedValue === "albumName" ? ["앨범 명", "곡 명"] : ["곡 명", "앨범 명"]}
+            dropdownListData={Object.values(SEARCH_BY_OPTIONS_MAP)}
+            initialValue={searchByValue}
             theme="withSearchBar"
             onClick={handleClickSearchByDropdown}
           />

--- a/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/AdminTrackStatusTable.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable function-call-argument-newline */
+/* eslint-disable function-paren-newline */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { useState, useRef } from "react";
@@ -7,6 +9,7 @@ import { useRouter } from "next/router";
 
 import Dropdown from "@/components/common/Dropdown/Dropdown";
 import Filter from "@/components/common/Filter/Filter";
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
 import Spacing from "@/components/common/Layouts/Spacing";
 import ProgressBar from "@/components/common/ProgressBar/ProgressBar";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
@@ -73,6 +76,24 @@ const AdminTrackStatusTable = ({
     ), undefined, { scroll: false });
   };
 
+  const handleSubmitFilter = (options: IFilterOptions) => {
+    const {
+      mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
+    } = options;
+    router.push(updateQueryParam(
+      router.query,
+      "mId", mId,
+      "revFr", revFr,
+      "revTo", revTo,
+      "netFr", netFr,
+      "netTo", netTo,
+      "setFr", setFr,
+      "setTo", setTo,
+      "comFr", comFr,
+      "comTo", comTo,
+      "page", 1), undefined, { scroll: false });
+  };
+
   return (
     <section className={cx("container")}>
       <div className={cx("titleContainer")}>
@@ -84,7 +105,7 @@ const AdminTrackStatusTable = ({
             onClick={handleClickSortByDropdown}
           />
           <Spacing direction="horizontal" size={18} />
-          <Filter />
+          <Filter onSubmit={handleSubmitFilter} />
           <Spacing direction="horizontal" size={32} />
           <Dropdown
             dropdownListData={Object.values(SEARCH_BY_OPTIONS_MAP)}

--- a/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
@@ -17,6 +17,7 @@ import TableContainerUI from "@/components/common/Table/Composition/TableContain
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
+import { REVERSE_SEARCH_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP } from "@/constants/trackStatusTable";
 import { ITrackTransaction } from "@/types/dto";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 import formatMoney from "@/utils/formatMoney";
@@ -33,13 +34,14 @@ interface ArtistTrackStatusTableProps {
   data: Omit<ITrackTransaction, "netIncome">[]
   isEmpty?: boolean
   paginationElement?: React.ReactNode
+  searchBy: string
 }
 
 const ArtistTrackStatusTable = ({
-  title, data, isEmpty = false, paginationElement,
+  title, data, isEmpty = false, paginationElement, searchBy,
 }: ArtistTrackStatusTableProps) => {
   const router = useRouter();
-  const [selectedValue, setSelectedValue] = useState(router.query?.searchBy === "albumName" ? "albumName" : "trackName");
+  const [searchByValue, setSearchByValue] = useState(SEARCH_BY_OPTIONS_MAP[searchBy] ?? "곡 명");
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   const handleClickSortByDropdown = (value: string) => {
@@ -47,7 +49,7 @@ const ArtistTrackStatusTable = ({
   };
 
   const handleClickSearchByDropdown = (value: string) => {
-    setSelectedValue(value === "곡 명" ? "trackName" : "albumName");
+    setSearchByValue(value);
   };
 
   const handleClickSearchBar = (event: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>) => {
@@ -55,7 +57,7 @@ const ArtistTrackStatusTable = ({
     router.push(updateQueryParam(
       router.query,
       "searchBy",
-      selectedValue,
+      REVERSE_SEARCH_BY_OPTIONS_MAP[searchByValue],
       "keyword",
       searchBarRef.current?.value ?? "",
     ), undefined, { scroll: false });
@@ -74,9 +76,10 @@ const ArtistTrackStatusTable = ({
           <Filter />
           <Spacing direction="horizontal" size={32} />
           <Dropdown
-            dropdownListData={selectedValue === "albumName" ? ["앨범 명", "곡 명"] : ["곡 명", "앨범 명"]}
             theme="withSearchBar"
             onClick={handleClickSearchByDropdown}
+            dropdownListData={Object.values(SEARCH_BY_OPTIONS_MAP)}
+            initialValue={searchByValue}
           />
           <form onSubmit={handleClickSearchBar}>
             <SearchBar placeholder="검색어를 입력해주세요" theme="withSearchBar" onClick={handleClickSearchBar} value={(router.query?.keyword ?? "") as string} ref={searchBarRef} />

--- a/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
@@ -51,6 +51,8 @@ const ArtistTrackStatusTable = ({
       router.query,
       "sortBy",
       REVERSE_SORT_BY_OPTIONS_MAP[value],
+      "page",
+      1,
     ), undefined, { scroll: false });
   };
 
@@ -66,6 +68,8 @@ const ArtistTrackStatusTable = ({
       REVERSE_SEARCH_BY_OPTIONS_MAP[searchByValue],
       "keyword",
       searchBarRef.current?.value ?? "",
+      "page",
+      1,
     ), undefined, { scroll: false });
   };
 

--- a/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable function-call-argument-newline */
+/* eslint-disable function-paren-newline */
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable max-len */
 import { useState, useRef } from "react";
@@ -7,6 +9,7 @@ import { useRouter } from "next/router";
 
 import Dropdown from "@/components/common/Dropdown/Dropdown";
 import Filter from "@/components/common/Filter/Filter";
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
 import Spacing from "@/components/common/Layouts/Spacing";
 import ProgressBar from "@/components/common/ProgressBar/ProgressBar";
 import SearchBar from "@/components/common/SearchBar/SearchBar";
@@ -73,6 +76,24 @@ const ArtistTrackStatusTable = ({
     ), undefined, { scroll: false });
   };
 
+  const handleSubmitFilter = (options: IFilterOptions) => {
+    const {
+      mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
+    } = options;
+    router.push(updateQueryParam(
+      router.query,
+      "mId", mId,
+      "revFr", revFr,
+      "revTo", revTo,
+      "netFr", netFr,
+      "netTo", netTo,
+      "setFr", setFr,
+      "setTo", setTo,
+      "comFr", comFr,
+      "comTo", comTo,
+      "page", 1), undefined, { scroll: false });
+  };
+
   return (
     <section className={cx("container")}>
       <div className={cx("titleContainer")}>
@@ -84,7 +105,7 @@ const ArtistTrackStatusTable = ({
             onClick={handleClickSortByDropdown}
           />
           <Spacing direction="horizontal" size={18} />
-          <Filter />
+          <Filter onSubmit={handleSubmitFilter} />
           <Spacing direction="horizontal" size={32} />
           <Dropdown
             theme="withSearchBar"

--- a/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
+++ b/src/components/dashboard/TrackStatusTable/ArtistTrackStatusTable.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable max-len */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useState, useRef } from "react";
 
 import classNames from "classnames/bind";
@@ -17,7 +16,9 @@ import TableContainerUI from "@/components/common/Table/Composition/TableContain
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
-import { REVERSE_SEARCH_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP } from "@/constants/trackStatusTable";
+import {
+  REVERSE_SEARCH_BY_OPTIONS_MAP, REVERSE_SORT_BY_OPTIONS_MAP, SEARCH_BY_OPTIONS_MAP, SORT_BY_OPTIONS_MAP,
+} from "@/constants/trackStatusTable";
 import { ITrackTransaction } from "@/types/dto";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 import formatMoney from "@/utils/formatMoney";
@@ -35,17 +36,22 @@ interface ArtistTrackStatusTableProps {
   isEmpty?: boolean
   paginationElement?: React.ReactNode
   searchBy: string
+  sortBy: string
 }
 
 const ArtistTrackStatusTable = ({
-  title, data, isEmpty = false, paginationElement, searchBy,
+  title, data, isEmpty = false, paginationElement, searchBy, sortBy,
 }: ArtistTrackStatusTableProps) => {
   const router = useRouter();
   const [searchByValue, setSearchByValue] = useState(SEARCH_BY_OPTIONS_MAP[searchBy] ?? "곡 명");
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   const handleClickSortByDropdown = (value: string) => {
-    // TODO: 정렬 순서 쿼리 파람 변경
+    router.push(updateQueryParam(
+      router.query,
+      "sortBy",
+      REVERSE_SORT_BY_OPTIONS_MAP[value],
+    ), undefined, { scroll: false });
   };
 
   const handleClickSearchByDropdown = (value: string) => {
@@ -69,7 +75,8 @@ const ArtistTrackStatusTable = ({
         <h2 className={cx("title")}>{title}</h2>
         <div className={cx("utilContainer")}>
           <Dropdown
-            dropdownListData={["매출순", "정산액순", "요율순"]}
+            dropdownListData={Object.values(SORT_BY_OPTIONS_MAP).filter((option) => { return option !== "회사 이익순"; })}
+            initialValue={SORT_BY_OPTIONS_MAP[sortBy] ?? "매출순"}
             onClick={handleClickSortByDropdown}
           />
           <Spacing direction="horizontal" size={18} />

--- a/src/constants/trackStatusTable.ts
+++ b/src/constants/trackStatusTable.ts
@@ -10,3 +10,14 @@ export const SEARCH_BY_OPTIONS_MAP: Options = {
 export const REVERSE_SEARCH_BY_OPTIONS_MAP: Options = Object.fromEntries(
   Object.entries(SEARCH_BY_OPTIONS_MAP).map(([key, value]) => { return [value, key]; }),
 );
+
+export const SORT_BY_OPTIONS_MAP: Options = {
+  revenue: "매출순",
+  netIncome: "회사 이익순",
+  settlement: "정산액순",
+  commissionRate: "요율순",
+};
+
+export const REVERSE_SORT_BY_OPTIONS_MAP: Options = Object.fromEntries(
+  Object.entries(SORT_BY_OPTIONS_MAP).map(([key, value]) => { return [value, key]; }),
+);

--- a/src/constants/trackStatusTable.ts
+++ b/src/constants/trackStatusTable.ts
@@ -1,0 +1,12 @@
+interface Options {
+  [key: string]: string;
+}
+
+export const SEARCH_BY_OPTIONS_MAP: Options = {
+  trackName: "곡 명",
+  albumName: "앨범 명",
+};
+
+export const REVERSE_SEARCH_BY_OPTIONS_MAP: Options = Object.fromEntries(
+  Object.entries(SEARCH_BY_OPTIONS_MAP).map(([key, value]) => { return [value, key]; }),
+);

--- a/src/pages/admin/dashboard/[month]/index.page.tsx
+++ b/src/pages/admin/dashboard/[month]/index.page.tsx
@@ -80,6 +80,7 @@ const AdminDashboardPage = ({
                 itemsPerPage={ITEMS_PER_DASHBOARD_TABLE}
               />
             )}
+            searchBy={searchBy}
           />
         )}
     </MainLayoutWithDropdown>

--- a/src/pages/admin/dashboard/[month]/index.page.tsx
+++ b/src/pages/admin/dashboard/[month]/index.page.tsx
@@ -81,6 +81,7 @@ const AdminDashboardPage = ({
               />
             )}
             searchBy={searchBy}
+            sortBy={sortBy}
           />
         )}
     </MainLayoutWithDropdown>

--- a/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
+++ b/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
@@ -81,6 +81,7 @@ const ArtistDashboardPage = ({
               />
             )}
             searchBy={searchBy}
+            sortBy={sortBy}
           />
         )}
     </MainLayoutWithDropdown>

--- a/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
+++ b/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
@@ -80,6 +80,7 @@ const ArtistDashboardPage = ({
                 itemsPerPage={ITEMS_PER_DASHBOARD_TABLE}
               />
             )}
+            searchBy={searchBy}
           />
         )}
     </MainLayoutWithDropdown>

--- a/src/services/api/requests/admin/admin.get.api.ts
+++ b/src/services/api/requests/admin/admin.get.api.ts
@@ -1,3 +1,5 @@
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
+
 import {
   IGetAdminAccountsResponse,
   IGetAdminDashboardResponse,
@@ -41,10 +43,22 @@ export const getAdminDashboardTable = async (
   sortBy: string | null,
   searchBy: string,
   keyword: string | null,
+  filterOptions: IFilterOptions,
 ) => {
-  const response = await getRequest<IGetAdminTrackTransactionResponse>(
-    `/admin/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword ?? ""}`,
-  );
+  let response;
+  if (Object.keys(filterOptions).length) {
+    const {
+      mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
+    } = filterOptions;
+    response = await getRequest<IGetAdminTrackTransactionResponse>(
+      `/admin/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword}`
+      + `&memberId=${mId}&revenueFrom=${revFr}&revenueTo=${revTo}&netIncomeFrom=${netFr}0&netIncomeTo=${netTo}&settlementFrom=${setFr}&settlementTo=${setTo}&commissionRateFrom=${comFr}&commissionRateTo=${comTo}`,
+    );
+  } else {
+    response = await getRequest<IGetAdminTrackTransactionResponse>(
+      `/admin/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword}`,
+    );
+  }
   return response;
 };
 

--- a/src/services/api/requests/artist/artist.get.api.ts
+++ b/src/services/api/requests/artist/artist.get.api.ts
@@ -1,3 +1,5 @@
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
+
 import {
   IGetArtistAlbumsResponse,
   IGetArtistDashboardResponse,
@@ -66,11 +68,23 @@ export const getArtistDashboardTable = async (
   sortBy: string | null,
   searchBy: string,
   keyword: string | null,
-  memberId: number,
+  filterOptions: IFilterOptions,
+  artistId: number,
 ) => {
-  const response = await getRequest<IGetArtistTrackTransactionResponse>(
-    `/artists/${memberId}/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy ?? ""}&searchType=${searchBy}&keyword=${keyword ?? ""}`,
-  );
+  let response;
+  if (Object.keys(filterOptions).length) {
+    const {
+      mId, revFr, revTo, netFr, netTo, setFr, setTo, comFr, comTo,
+    } = filterOptions;
+    response = await getRequest<IGetArtistTrackTransactionResponse>(
+      `/artists/${artistId}/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword}`
+      + `&memberId=${mId}&revenueFrom=${revFr}&revenueTo=${revTo}&netIncomeFrom=${netFr}0&netIncomeTo=${netTo}&settlementFrom=${setFr}&settlementTo=${setTo}&commissionRateFrom=${comFr}&commissionRateTo=${comTo}`,
+    );
+  } else {
+    response = await getRequest<IGetArtistTrackTransactionResponse>(
+      `/artists/${artistId}/dashboard/track?monthly=${month}&page=${page - 1}&size=${size}&sortBy=${sortBy}&searchType=${searchBy}&keyword=${keyword}`,
+    );
+  }
   return response;
 };
 

--- a/src/services/queries/dashboard/queryFns/table.ts
+++ b/src/services/queries/dashboard/queryFns/table.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
 import { MOCK_ADMIN_TABLE, MOCK_ARTIST_TABLE } from "@/constants/mock";
 import { ITEMS_PER_DASHBOARD_TABLE } from "@/constants/pagination";
 import { getAdminDashboardTable } from "@/services/api/requests/admin/admin.get.api";
@@ -14,6 +15,7 @@ export const getDashboardTable = async (
   sortBy: string,
   searchBy: string,
   keyword: string,
+  filterOptions: IFilterOptions,
   artistId?: number,
 ) => {
   const data = (type === DASHBOARD_TYPE.ADMIN)
@@ -24,6 +26,7 @@ export const getDashboardTable = async (
       sortBy,
       searchBy,
       keyword,
+      filterOptions,
     )
     : await getArtistDashboardTable(
       month,
@@ -32,6 +35,7 @@ export const getDashboardTable = async (
       sortBy,
       searchBy,
       keyword,
+      filterOptions,
       artistId!,
     );
   return data;

--- a/src/services/queries/dashboard/useAdminDashboard.ts
+++ b/src/services/queries/dashboard/useAdminDashboard.ts
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
 import { PAGES_PER_PAGINATION } from "@/constants/pagination";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 
@@ -19,6 +20,7 @@ const useAdminDashboard = (
   sortBy: string,
   searchBy: string,
   keyword: string,
+  filterOptions: IFilterOptions,
 ) => {
   const queries = useQueries({
     queries: [
@@ -42,10 +44,10 @@ const useAdminDashboard = (
       },
       {
         queryKey: [DASHBOARD_TYPE.ADMIN, "dashboard", "table", {
-          month, page, sortBy, searchBy, keyword,
+          month, page, sortBy, searchBy, keyword, filterOptions,
         }],
         queryFn: () => {
-          return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, page, sortBy, searchBy, keyword);
+          return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, page, sortBy, searchBy, keyword, filterOptions);
         },
       },
     ],
@@ -59,18 +61,18 @@ const useAdminDashboard = (
     if (endPage) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ADMIN, "dashboard", "table", {
-          month, page: endPage, sortBy, searchBy, keyword,
+          month, page: endPage, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, endPage, sortBy, searchBy, keyword); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, endPage, sortBy, searchBy, keyword, filterOptions); },
       );
     }
 
     // 2. 1페이지
     void queryClient.prefetchQuery(
       [DASHBOARD_TYPE.ADMIN, "dashboard", "table", {
-        month, page: 1, sortBy, searchBy, keyword,
+        month, page: 1, sortBy, searchBy, keyword, filterOptions,
       }],
-      () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, 1, sortBy, searchBy, keyword); },
+      () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, 1, sortBy, searchBy, keyword, filterOptions); },
     );
 
     const curPaginationStartPage = Math.floor((page - 1) / PAGES_PER_PAGINATION) * PAGES_PER_PAGINATION + 1;
@@ -81,9 +83,9 @@ const useAdminDashboard = (
     for (let i = curPaginationStartPage; i <= Math.min(endPage, nextPaginationStartPage); i += 1) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ADMIN, "dashboard", "table", {
-          month, page: i, sortBy, searchBy, keyword,
+          month, page: i, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, i, sortBy, searchBy, keyword); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, i, sortBy, searchBy, keyword, filterOptions); },
       );
     }
 
@@ -91,12 +93,12 @@ const useAdminDashboard = (
     if (prevPaginationstartPage >= 1) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ADMIN, "dashboard", "table", {
-          month, page: prevPaginationstartPage, sortBy, searchBy, keyword,
+          month, page: prevPaginationstartPage, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, prevPaginationstartPage, sortBy, searchBy, keyword); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ADMIN, month, prevPaginationstartPage, sortBy, searchBy, keyword, filterOptions); },
       );
     }
-  }, [keyword, month, page, queries, queryClient, searchBy, sortBy]);
+  }, [keyword, month, page, queries, queryClient, searchBy, sortBy, filterOptions]);
 
   return queries;
 };

--- a/src/services/queries/dashboard/useArtistDashboard.ts
+++ b/src/services/queries/dashboard/useArtistDashboard.ts
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 
+import { IFilterOptions } from "@/components/common/Filter/Filter.type";
 import { PAGES_PER_PAGINATION } from "@/constants/pagination";
 import { DASHBOARD_TYPE } from "@/types/enums/dashboard.enum";
 
@@ -20,6 +21,7 @@ const useArtistDashboard = (
   searchBy: string,
   keyword: string,
   artistId: number,
+  filterOptions: IFilterOptions,
 ) => {
   const queries = useQueries({
     queries: [
@@ -43,10 +45,10 @@ const useArtistDashboard = (
       },
       {
         queryKey: [DASHBOARD_TYPE.ARTIST, "dashboard", "table", artistId, {
-          month, page, sortBy, searchBy, keyword,
+          month, page, sortBy, searchBy, keyword, filterOptions,
         }],
         queryFn: () => {
-          return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, page, sortBy, searchBy, keyword, artistId);
+          return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, page, sortBy, searchBy, keyword, filterOptions, artistId);
         },
       },
     ],
@@ -60,18 +62,18 @@ const useArtistDashboard = (
     if (endPage) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ARTIST, "dashboard", "table", artistId, {
-          month, page: endPage, sortBy, searchBy, keyword,
+          month, page: endPage, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, endPage, sortBy, searchBy, keyword, artistId); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, endPage, sortBy, searchBy, keyword, filterOptions, artistId); },
       );
     }
 
     // 2. 1페이지
     void queryClient.prefetchQuery(
       [DASHBOARD_TYPE.ARTIST, "dashboard", "table", artistId, {
-        month, page: 1, sortBy, searchBy, keyword,
+        month, page: 1, sortBy, searchBy, keyword, filterOptions,
       }],
-      () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, 1, sortBy, searchBy, keyword, artistId); },
+      () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, 1, sortBy, searchBy, keyword, filterOptions, artistId); },
     );
 
     const curPaginationStartPage = Math.floor((page - 1) / PAGES_PER_PAGINATION) * PAGES_PER_PAGINATION + 1;
@@ -82,9 +84,9 @@ const useArtistDashboard = (
     for (let i = curPaginationStartPage; i <= Math.min(endPage, nextPaginationStartPage); i += 1) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ARTIST, "dashboard", "table", artistId, {
-          month, page: i, sortBy, searchBy, keyword,
+          month, page: i, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, i, sortBy, searchBy, keyword, artistId); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, i, sortBy, searchBy, keyword, filterOptions, artistId); },
       );
     }
 
@@ -92,12 +94,12 @@ const useArtistDashboard = (
     if (prevPaginationstartPage >= 1) {
       void queryClient.prefetchQuery(
         [DASHBOARD_TYPE.ARTIST, "dashboard", "table", artistId, {
-          month, page: prevPaginationstartPage, sortBy, searchBy, keyword,
+          month, page: prevPaginationstartPage, sortBy, searchBy, keyword, filterOptions,
         }],
-        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, prevPaginationstartPage, sortBy, searchBy, keyword, artistId); },
+        () => { return getDashboardTable(DASHBOARD_TYPE.ARTIST, month, prevPaginationstartPage, sortBy, searchBy, keyword, filterOptions, artistId); },
       );
     }
-  }, [artistId, keyword, month, page, queries, queryClient, searchBy, sortBy]);
+  }, [artistId, keyword, month, page, queries, queryClient, searchBy, sortBy, filterOptions]);
 
   return queries;
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 공통 컴포넌트 수정
  - `드롭다운`: 선택적으로 초기값을 받을 수 있도록 수정
- 정렬 기능 구현
- 필터 기능 구현
  - 구현 간 기존 UI 구현되어있던 `Filter`, `FilterForm`, `MultiRangeSlider` 컴포넌트 내부 일부 수정

![DemoCreatorRec_2023-10-30-23-29-30](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/83b5575f-af32-47a4-a391-d03ff1091a86)


### How it Works
<!-- 간단한 로직 설명 -->

- 필터 기능
  - 필터 적용 시 **비제어 방식**으로 필터 옵션 값을 가져와 쿼리에 반영
  - (예외적으로 아티스트명(드롭다운)은 제어 방식으로 가져옴

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->

- 테스트 하다보니 **필터 초기화** 기능이 있으면 좋겠다고 생각이 드네요. "필터 초기화" UI를 어떻게 할지만 정하면 구현은 어렵지 않을 것 같습니다.
- 필터의 각 옵션을 풀네임으로 URL 쿼리에 담기엔 너무 길이가 길어서 `memberId -> mId`, `revenueFrom -> revFr`, `revenueTo -> revTo` 등으로 축약하여 썼는데 어떤가요??