### PR TITLE
BPS-386/SUPER_ADMIN인 경우에만 pending status 여부 확인 api 호출

### DIFF
--- a/src/components/layout/GNB/PCGNB.tsx
+++ b/src/components/layout/GNB/PCGNB.tsx
@@ -33,7 +33,7 @@ const PCGNB = ({
   const profileURL = (type === MEMBER_TYPE.ADMIN)
     ? "/admin/my-profile"
     : `/artists/${memberId}/my-profile`;
-  const { data: hasCheckPendingStatus } = useCheckPendingStatus();
+  const { data: hasCheckPendingStatus } = useCheckPendingStatus(role);
 
   return (
     <div className={cx("container")}>

--- a/src/services/queries/notification-controller/useCheckPendingStatus.ts
+++ b/src/services/queries/notification-controller/useCheckPendingStatus.ts
@@ -1,11 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { getCheckPendingStatus } from "@/services/api/requests/notification-controller/notification-controller.get.api";
+import { MemberRole } from "@/types/enums/user.enum";
 
-const useCheckPendingStatus = () => {
+const useCheckPendingStatus = (role: MemberRole) => {
   const response = useQuery(["check-pending-status"], getCheckPendingStatus, {
     refetchInterval: 3 * 60 * 1000,
     refetchIntervalInBackground: true,
+    enabled: role === "SUPER_ADMIN",
   });
   return response;
 };


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명
기존에 GNB에서 유저 role에 상관없이 pending status 여부 확인 api 훅을 호출하는 문제가 있었습니다. => `SPUER_ADMIN`일 때만 호출하도록 수정했습니다.
아마 지금 develop 브랜치에서 아티스트로 로그인하면 바로 403 페이지로 빠질텐데, 이게 원인이었던 듯 합니다!

