### PR TITLE
BPS-391/앨범 정보 모달에서 앨범명이 길 때 ellipsis 처리

### DIFF
--- a/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.module.scss
+++ b/src/components/dashboard/AlbumInfoModal/AlbumInfoModal.module.scss
@@ -18,6 +18,7 @@
       display: inline-flex;
       flex-direction: column;
       align-items: center;
+      width: 346px;
       margin-right: 96px;
       color: $primary-black;
       vertical-align: top;
@@ -41,6 +42,10 @@
 
       .albumTitle {
         @include typo(24, bold);
+        @include ellipsis;
+
+        width: 100%;
+        text-align: center;
       }
 
       .hr {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->

- 앨범 정보 모달에서 앨범명이 길 때 ellipsis 처리
(호버 툴팁 기능은 대시보드에 앨범명이 나오기 때문에 불필요할 것 같아 넣지 않았습니다)

![image](https://github.com/Bluekey-Payment-System/BPS-FE/assets/125791542/b851738e-68d1-4141-9edc-c1f90637d3ec)

