### PR TITLE
BPS-392/트랙 삭제 기능 추가

### DIFF
--- a/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
+++ b/src/components/album/AlbumTrackListTable/AlbumTrackListTable.tsx
@@ -5,13 +5,17 @@ import Image from "next/image";
 
 import AddTrackModal from "@/components/album/AddTrackModal/AddTrackModal";
 import ChipButton from "@/components/common/CommonBtns/ChipButton/ChipButton";
+import AlertModal from "@/components/common/Modals/AlertModal/AlertModal";
 import TableBodyUI from "@/components/common/Table/Composition/TableBodyUI";
 import TableCellUI from "@/components/common/Table/Composition/TableCellUI";
 import TableContainerUI from "@/components/common/Table/Composition/TableContainerUI";
 import TableHeaderUI from "@/components/common/Table/Composition/TableHeaderUI";
 import TableRowUI from "@/components/common/Table/Composition/TableRowUI";
 import TooltipRoot from "@/components/common/Tooltip/TooltipRoot";
+import useToast from "@/hooks/useToast";
+import useDeleteAlbumTrack from "@/services/queries/tracks/useDeleteAlbumTrack";
 import { ITrackInfo } from "@/types/dto";
+import { MODAL_TYPE } from "@/types/enums/modal.enum";
 
 import styles from "./AlbumTrackListTable.module.scss";
 
@@ -25,7 +29,10 @@ interface AlbumTrackListTableProps {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
   const [isEditTrackModalOpen, setIsEditTrackModalOpen] = useState(false);
-  const [selectedTrackInfo, setSelectedTrackInfo] = useState<ITrackInfo>();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedTrackInfo, setSelectedTrackInfo] = useState<ITrackInfo>(tracks[0]);
+  const { mutateAsync: deleteTrack } = useDeleteAlbumTrack(albumId);
+  const { showToast } = useToast();
   return (
     <TableContainerUI
       stickyLastCol
@@ -88,7 +95,13 @@ const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
                   >
                     수정
                   </ChipButton>
-                  <ChipButton onClick={() => { }}>삭제</ChipButton>
+                  <ChipButton onClick={() => {
+                    setIsDeleteModalOpen(true);
+                    setSelectedTrackInfo(item);
+                  }}
+                  >
+                    삭제
+                  </ChipButton>
                 </div>
               </TableCellUI>
             </TableRowUI>
@@ -100,6 +113,25 @@ const AlbumTrackListTable = ({ albumId, tracks }: AlbumTrackListTableProps) => {
         onClose={() => { setIsEditTrackModalOpen(false); }}
         albumId={albumId}
         trackInfo={selectedTrackInfo}
+      />
+      <AlertModal
+        open={isDeleteModalOpen}
+        type={MODAL_TYPE.CONFIRM}
+        title="수록곡 삭제"
+        message={`수록곡 "${selectedTrackInfo?.name}"을 삭제 하시겠습니까?`}
+        closeBtnText="취소"
+        proceedBtnText="삭제"
+        onClickProceed={async () => {
+          try {
+            await deleteTrack(selectedTrackInfo?.trackId);
+            showToast(`수록곡 "${selectedTrackInfo.name}"이(가)) 삭제되었습니다.`);
+          } catch (err) {
+            showToast("일시적인 오류가 발생했습니다. 잠시 뒤에 다시 시도해주세요.", "toast-root", "FAIL");
+          } finally {
+            setIsDeleteModalOpen(false);
+          }
+        }}
+        onClose={() => { setIsDeleteModalOpen(false); }}
       />
     </TableContainerUI>
   );

--- a/src/components/common/Modals/AlertModal/AlertModal.tsx
+++ b/src/components/common/Modals/AlertModal/AlertModal.tsx
@@ -14,7 +14,7 @@ export interface AlertModalProps {
   type: Extract<ModalType, (typeof MODAL_TYPE)["ERROR"] | (typeof MODAL_TYPE)["CONFIRM"]>;
   title: string;
   message: string;
-  onClickProceed?: ()=>void;
+  onClickProceed?: (() => void) | (() => Promise<void>);
   proceedBtnText?: string;
   closeBtnText?: string;
   onClose: () => void;
@@ -78,9 +78,9 @@ const AlertModal = ({
           {proceedBtnText ?? closeBtnText}
         </Button>
         {onClickProceed && (
-          <button className={cx("closeBtnWithProceed")} onClick={onClose}>
+          <Button size="large" theme="bright" className={cx("closeBtnWithProceed")} onClick={onClose}>
             {closeBtnText}
-          </button>
+          </Button>
         )}
       </div>
     </Modal>

--- a/src/components/common/Modals/AlertModal/AlertModalRoot.tsx
+++ b/src/components/common/Modals/AlertModal/AlertModalRoot.tsx
@@ -16,7 +16,8 @@ const AlertModalRoot = () => {
     }, 500);
   };
   const onClickProceedWithClose = () => {
-    alertModalProps?.onClickProceed!();
+    // eslint-disable-next-line no-void
+    void alertModalProps?.onClickProceed!();
     onClose();
   };
 

--- a/src/services/queries/tracks/useDeleteAlbumTrack.ts
+++ b/src/services/queries/tracks/useDeleteAlbumTrack.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteTrack } from "@/services/api/requests/tracks/tracks.delete.api";
+import { IDeleteTrackResponse } from "@/services/api/types/tracks";
+
+type TrackId = number;
+
+const useDeleteAlbumTrack = (albumId: number) => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<
+  IDeleteTrackResponse,
+  unknown,
+  TrackId,
+  unknown
+  >(
+    deleteTrack,
+    {
+      onSuccess: () => {
+        // eslint-disable-next-line no-void
+        void queryClient.invalidateQueries({ queryKey: ["albums", albumId] });
+      },
+    },
+  );
+
+  return mutation;
+};
+
+export default useDeleteAlbumTrack;


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [X] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes

<!-- 어떤 작업을 했는지 -->
- 어드민이 앨범 수정 페이지에서 트랙을 삭제할 수 있는 기능을 추가했습니다. 
### How it Works
<!-- 간단한 로직 설명 -->
- 다른 api와 마찬가지로 트랙 삭제용 뮤테이션 훅을 만들어 삭제 버튼에 연동시키고, 에러 처리 및 후처리(토스트) 로직을 추가했습니다. 
### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
