### PR TITLE
BPS-393/유저 타입에 따른 차트 데이터 변경

### DIFF
--- a/src/components/common/Chart/BarChart/BarChart.tsx
+++ b/src/components/common/Chart/BarChart/BarChart.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import { ResponsiveBar } from "@nivo/bar";
 import classNames from "classnames/bind";
 
@@ -49,18 +47,9 @@ const BarChart = ({ barChartData, type }: {
   barChartData: IGetAdminMonthlyTrendsResponse,
   type: MemberRole
 }) => {
-  const checkAllZeros = useCallback(
-    (chartData: IGetAdminMonthlyTrendsResponse): boolean => {
-      return chartData.contents.every((entry) => {
-        return entry.revenue === 0 && entry.netIncome === 0 && entry.settlement === 0;
-      });
-    },
-    [],
-  );
-
   const maxValue: number = getMaxValue(barChartData, type);
   const formattedData = mapChartDataToMonthlySummary(barChartData, type);
-  const keyType = type === MEMBER_ROLE.ARTIST ? ["revenue", "settlement"] : ["revenue", "netIncome"];
+  const keyType = type === MEMBER_ROLE.ARTIST ? ["settlement"] : ["revenue", "netIncome"];
 
   return (
     <ResponsiveBar
@@ -73,7 +62,8 @@ const BarChart = ({ barChartData, type }: {
           },
         },
       }}
-      maxValue={checkAllZeros(barChartData) ? 10000 : maxValue * 1.2}
+      // maxValue={checkAllZeros(barChartData) ? 10000 : maxValue * 1.2}
+      maxValue={maxValue === 0 ? 10000 : maxValue * 1.2}
       barComponent={BarItem}
       borderRadius={7}
       data={formattedData}
@@ -83,7 +73,7 @@ const BarChart = ({ barChartData, type }: {
       margin={{
         top: 60, right: -35, bottom: 20, left: 45,
       }}
-      padding={0.7}
+      padding={type === MEMBER_ROLE.ARTIST ? 0.87 : 0.7}
       innerPadding={3}
       groupMode="grouped"
       valueScale={{ type: "linear" }}

--- a/src/components/common/Chart/BarChart/BarChart.utils.ts
+++ b/src/components/common/Chart/BarChart/BarChart.utils.ts
@@ -31,7 +31,6 @@ export const mapChartDataToMonthlySummary = (
     if (type === MEMBER_ROLE.ARTIST) {
       return {
         month: getMonthName(data.month),
-        revenue: data.revenue,
         settlement: data.settlement,
       };
     }
@@ -52,18 +51,14 @@ export const getMaxValue = (
   let maxValue = 0;
 
   for (let i = 0; i < chartData.contents.length; i += 1) {
-    let valueToCompare = 0;
     const content = chartData.contents[i];
 
     if (type === MEMBER_ROLE.ARTIST) {
-      valueToCompare = Math.max(content.settlement || 0, content.revenue as number);
+      maxValue = Math.max(maxValue, content.settlement || 0);
     } else {
-      valueToCompare = Math.max(content.netIncome || 0, content.revenue as number);
-    }
-
-    if (valueToCompare > maxValue) {
-      maxValue = valueToCompare;
+      maxValue = Math.max(maxValue, content.netIncome || 0, content.revenue || 0);
     }
   }
+
   return maxValue;
 };

--- a/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
+++ b/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
@@ -28,7 +28,7 @@ const MonthlyTrendChart = ({ barChartData, type }: MonthlyTrendChartProps) => {
         <span>{`월별 ${type === MEMBER_ROLE.ARTIST ? "정산액" : "매출"} 추이`}</span>
         <div className={cx("legendContainer")}>
           {type !== MEMBER_ROLE.ARTIST && <CustomLegend color="#387ffd" text="매출" type="bar" />}
-          <CustomLegend color="#bfd4f9" text={type === MEMBER_ROLE.ARTIST ? "정산액" : "회사 이익"} type="bar" />
+          <CustomLegend color={type === MEMBER_ROLE.ARTIST ? "#387ffd" : "#bfd4f9"} text={type === MEMBER_ROLE.ARTIST ? "정산액" : "회사 이익"} type="bar" />
         </div>
       </div>
       <div className={cx("chartWrapper")}>

--- a/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
+++ b/src/components/dashboard/MonthlyTrendsChart/MonthlyTrendsChart.tsx
@@ -27,7 +27,7 @@ const MonthlyTrendChart = ({ barChartData, type }: MonthlyTrendChartProps) => {
       <div className={cx("description")}>
         <span>{`월별 ${type === MEMBER_ROLE.ARTIST ? "정산액" : "매출"} 추이`}</span>
         <div className={cx("legendContainer")}>
-          <CustomLegend color="#387ffd" text="매출" type="bar" />
+          {type !== MEMBER_ROLE.ARTIST && <CustomLegend color="#387ffd" text="매출" type="bar" />}
           <CustomLegend color="#bfd4f9" text={type === MEMBER_ROLE.ARTIST ? "정산액" : "회사 이익"} type="bar" />
         </div>
       </div>

--- a/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChart.tsx
+++ b/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChart.tsx
@@ -6,20 +6,24 @@ import { useRouter } from "next/router";
 import DoughnutChart from "@/components/common/Chart/DoughnutChart/DoughnutChart";
 import { IGetAdminEarningsTopArtistResponse } from "@/services/api/types/admin";
 import { IGetAlbumRevenueTopTrackResponse } from "@/services/api/types/albums";
+import { MemberRole } from "@/types/enums/user.enum";
 
 import styles from "./TopFiveRevenueChart.module.scss";
-import routeBasedOnPath from "./TopFiveRevenueChart.utils";
+import getHeaderText from "./TopFiveRevenueChart.utils";
 import TopFiveRevenueChartLegend from "./TopFiveRevenueChartLegend";
 
 const cx = classNames.bind(styles);
 
-type TopFiveRevenueChartProps = IGetAdminEarningsTopArtistResponse | IGetAlbumRevenueTopTrackResponse;
+interface TopFiveRevenueChartProps {
+  topFiveChartData: IGetAdminEarningsTopArtistResponse | IGetAlbumRevenueTopTrackResponse;
+  type: MemberRole
+}
 
 /**
  * @author 임병욱
  * @param topFiveChartData - 차트 데이터 contents 값 포함해서 가져오면 됩니다
 */
-const TopFiveRevenueChart = ({ topFiveChartData }: { topFiveChartData: TopFiveRevenueChartProps }) => {
+const TopFiveRevenueChart = ({ topFiveChartData, type }: TopFiveRevenueChartProps) => {
   const router = useRouter();
 
   if (topFiveChartData.contents.length === 0) {
@@ -41,7 +45,7 @@ const TopFiveRevenueChart = ({ topFiveChartData }: { topFiveChartData: TopFiveRe
   return (
     <div className={cx("topFiveChartContainer")}>
       <div className={cx("description")}>
-        <span>{routeBasedOnPath(router.asPath)}</span>
+        <span>{getHeaderText(router.asPath, type)}</span>
       </div>
       <div className={cx("contentContainer")}>
         <div style={{ width: "300px", height: "300px" }}>

--- a/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChart.utils.ts
+++ b/src/components/dashboard/TopFiveRevenueChart/TopFiveRevenueChart.utils.ts
@@ -1,16 +1,18 @@
+import { MemberRole } from "@/types/enums/user.enum";
 import getParentPathFromUrl from "@/utils/getParentPathFromUrl";
 
-const getHeaderText = (currentPath: string | null) => {
-  if (currentPath === "/admin/dashboard") {
+const getHeaderText = (currentPath: string, type: MemberRole) => {
+  const parentPath = getParentPathFromUrl(currentPath);
+
+  if (parentPath === "/admin/dashboard") {
     return "당월 Top 5 아티스트 매출 비중";
+  }
+
+  if (type === "ARTIST") {
+    return "당월 Top 5 트랙 정산 비중";
   }
   // '/dashboard' 또는 '/albums/{albumId}'인 경우
   return "당월 Top 5 트랙 매출 비중";
 };
 
-const routeBasedOnPath = (currentPath: string) => {
-  const headerText = getHeaderText(getParentPathFromUrl(currentPath));
-  return headerText;
-};
-
-export default routeBasedOnPath;
+export default getHeaderText;

--- a/src/pages/admin/dashboard/[month]/index.page.tsx
+++ b/src/pages/admin/dashboard/[month]/index.page.tsx
@@ -66,7 +66,7 @@ const AdminDashboardPage = ({
       <DashboardCardList data={cardQuery.data!.cards} />
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <MonthlyTrendChart barChartData={trendsChartQuery.data!} type={MEMBER_TYPE.ADMIN} />
-        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} />
+        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} type={MEMBER_TYPE.ADMIN} />
       </div>
       {isTableLoading
         ? <div className={cx("loading", "table")}><Orbit dark /></div>

--- a/src/pages/albums/[albumId]/[month]/index.page.tsx
+++ b/src/pages/albums/[albumId]/[month]/index.page.tsx
@@ -58,7 +58,7 @@ const AlbumDashboardPage = ({ month, albumId }: InferGetServerSidePropsType<GetS
       <DashboardCardList data={cardQuery.data!.cards} />
       <div className={cx("chartContainer")}>
         <MonthlyTrendChart barChartData={trendsChartQuery.data!} type={memberRole as MemberRole} />
-        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} />
+        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} type={memberRole as MemberRole} />
       </div>
       <AlbumTrendsChart
         albumTrendsChartData={albumTrendsChartQuery.data!}

--- a/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
+++ b/src/pages/artists/[artistId]/dashboard/[month]/index.page.tsx
@@ -67,7 +67,7 @@ const ArtistDashboardPage = ({
       <DashboardCardList data={cardQuery.data!.cards} />
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <MonthlyTrendChart barChartData={trendsChartQuery.data!} type={memberRole as MemberRole} />
-        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} />
+        <TopFiveRevenueChart topFiveChartData={topFiveChartQuery.data!} type={memberRole as MemberRole} />
       </div>
       {isTableLoading
         ? <div className={cx("loading", "table")}><Orbit /></div>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### Key Changes
1. 아티스트 대시보드와 앨범 대시보드에서 어드민이 접근하게 되면 매출액과 회사이익을 보여주며 아티스트가 접근하게 되면 정산액을 보여주는 기능으로 수정
2. 아티스트 대시보드 & 앨범 대시보드에서 어드민이 접근하게 되면 매출액을 보여주며 아티스트가 접근하게 되면 정산액을 보여주는 기능으로 수정했습니다.

### How it Works
<!-- 간단한 로직 설명 -->

### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
